### PR TITLE
Add db_sync_level to config

### DIFF
--- a/src-tauri/src/setup/config.rs
+++ b/src-tauri/src/setup/config.rs
@@ -89,6 +89,7 @@ fn initial_config(admin_port: u16, environment_path: PathBuf) -> String {
         tuning_params:
             gossip_strategy: "sharded-gossip"
             default_rpc_multi_remote_request_grace_ms: 10
+    db_sync_level: Off
     "#,
     environment_path.into_os_string().to_str().unwrap(),
     keystore_data_path().into_os_string().to_str().unwrap(),


### PR DESCRIPTION
Launcher draft version 0.2.3 isn't working for me on a recent holochain (basically 0.0.107) because it doesn't specify `db_sync_level`. This PR adds the config option and specifies the value that is most performant from my understanding. However, I'm not sure if this change is compatible with older versions of holochain.