### PR TITLE
fixed holochain version ordering in installed apps list

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -164,10 +164,12 @@ export const store = createStore<LauncherAdminState>({
 
       const versions: Array<HolochainId> = Object.keys(
         stateInfo.state.content.content.versions
-      ).map((v) => ({
-        type: "HolochainVersion",
-        content: v,
-      }));
+      )
+        .sort((a, b) => b.localeCompare(a))
+        .map((v) => ({
+          type: "HolochainVersion",
+          content: v,
+        }));
       if (
         stateInfo.state.content.content.custom_binary &&
         stateInfo.state.content.content.custom_binary.type === "Running"


### PR DESCRIPTION
Fixes the ordering of holochain versions in the list of installed apps. From latest on top to oldest at the bottom.