### PR TITLE
make header section of the App Library screen independent of loading progress

### DIFF
--- a/src/components/setup/Setup.vue
+++ b/src/components/setup/Setup.vue
@@ -84,12 +84,15 @@ export default defineComponent({
   },
   methods: {
     async initialize() {
-      this.initializing = true;
-      const password = (this.$refs["password"] as TextField).value;
+      if (!this.initializing && this.isPasswordValid) {
+        // condition required to omit ENTER key triggering initialization
+        this.initializing = true;
+        const password = (this.$refs["password"] as TextField).value;
 
-      await invoke("initialize_keystore", { password });
-      await this.$store.dispatch(ActionTypes.fetchStateInfo);
-      this.initializing = false;
+        await invoke("initialize_keystore", { password });
+        await this.$store.dispatch(ActionTypes.fetchStateInfo);
+        this.initializing = false;
+      }
     },
   },
 });

--- a/src/components/setup/Setup.vue
+++ b/src/components/setup/Setup.vue
@@ -24,6 +24,7 @@
         helper=" "
         style="margin-top: 24px"
         label="Password"
+        dialogInitialFocus
       ></mwc-textfield>
 
       <mwc-textfield

--- a/src/views/AppStore.vue
+++ b/src/views/AppStore.vue
@@ -1,8 +1,5 @@
 <template>
-  <div v-if="loading" class="column center-content" style="flex: 1">
-    <mwc-circular-progress indeterminate></mwc-circular-progress>
-  </div>
-  <div v-else class="column" style="flex: 1; margin: 8px">
+  <div class="column" style="flex: 1; margin: 8px">
     <div class="row center-content">
       <mwc-icon-button
         icon="arrow_back"
@@ -26,8 +23,12 @@
       </mwc-button>
     </div>
 
+    <div v-if="loading" class="column center-content" style="flex: 1">
+      <mwc-circular-progress indeterminate></mwc-circular-progress>
+    </div>
+
     <div
-      v-if="installableApps.length === 0"
+      v-else-if="installableApps.length === 0"
       class="column center-content"
       style="flex: 1"
     >


### PR DESCRIPTION
* makes the top bar section of the App Library screen independent of the loading progress of the Apps from the devhub. This way it is possible to install an app from the file system even if fetching available happs from the devhub is still pending (may take a long time sometimes). Loading progress is only shown in the lower section.
* fixes issue #47 
* puts initial focus on password field in the setup password dialog