### PR TITLE
add hdi version and change version number of devhub to hdi version

### DIFF
--- a/crates/holochain_manager/src/errors.rs
+++ b/crates/holochain_manager/src/errors.rs
@@ -36,8 +36,8 @@ impl From<io::Error> for LaunchHolochainError {
 
 #[derive(Error, Serialize, Deserialize, Debug, Clone)]
 pub enum InitializeConductorError {
-  #[error("Unknown Fatal Panic: `{0}`")]
-  UnknownFatalPanic(String),
+  #[error("Unknown Error: `{0}`")]
+  UnknownError(String),
   #[error("Could not connect to the database of the conductor: `{0}`")]
   SqliteError(String),
   #[error("Address already in use: `{0}`")]

--- a/crates/holochain_manager/src/holochain_manager.rs
+++ b/crates/holochain_manager/src/holochain_manager.rs
@@ -15,12 +15,11 @@ use crate::{
   config::LaunchHolochainConfig,
   errors::LaunchHolochainError,
   launch::launch_holochain_process,
-  versions::{version_manager::VersionManager, HolochainVersion, HolochainVersionManager},
+  versions::{version_manager::VersionManager, HolochainVersion},
 };
 
 pub struct HolochainManager {
   pub version: HolochainVersion,
-  version_manager: HolochainVersionManager,
 
   admin_interface_port: u16,
   app_interface_port: u16,
@@ -108,7 +107,6 @@ impl HolochainManager {
 
     Ok(HolochainManager {
       version,
-      version_manager,
       ws,
       admin_interface_port: config.admin_port,
       app_interface_port,

--- a/crates/holochain_manager/src/launch.rs
+++ b/crates/holochain_manager/src/launch.rs
@@ -63,10 +63,10 @@ pub async fn launch_holochain_process(
 
         log::info!("[HOLOCHAIN v{}] {}", version, line);
 
-        if line.contains("FATAL PANIC PanicInfo") {
+        if line.contains("this is embarrassing") {
           launch_state = LaunchHolochainProcessState::InitializeConductorError(
-            InitializeConductorError::UnknownFatalPanic(
-              String::from("Unknown fatal panic when trying to initialize conductor. See log file for details.")
+            InitializeConductorError::UnknownError(
+              String::from("Unknown error when trying to initialize conductor. See log file for details.")
             )
           );
         }

--- a/crates/holochain_manager/src/versions/mod.rs
+++ b/crates/holochain_manager/src/versions/mod.rs
@@ -30,6 +30,25 @@ pub enum HdkVersion {
   V0_0_152,
 }
 
+impl Into<String> for HdkVersion {
+  fn into(self) -> String {
+    self.to_string()
+  }
+}
+
+// NEW_VERSION: Add the new HDK version to this enum (if there is a new HDK version)
+#[derive(Copy, Clone, Debug, PartialEq, Hash, Eq, Deserialize_enum_str, Serialize_enum_str)]
+pub enum HdiVersion {
+  #[serde(rename = "0.1.2")]
+  V0_1_2,
+}
+
+impl Into<String> for HdiVersion {
+  fn into(self) -> String {
+    self.to_string()
+  }
+}
+
 // NEW_VERSION: Add the new Holochain version to this enum
 #[derive(Copy, Clone, Debug, PartialEq, Hash, Eq, Deserialize_enum_str, Serialize_enum_str)]
 pub enum HolochainVersion {

--- a/crates/holochain_manager/src/versions/v0_0_162.rs
+++ b/crates/holochain_manager/src/versions/v0_0_162.rs
@@ -8,7 +8,7 @@ use holochain_conductor_api_0_0_162::{
 };
 use holochain_p2p_0_0_162::kitsune_p2p::{KitsuneP2pConfig, ProxyConfig, TransportConfig, dependencies::kitsune_p2p_types::config::tuning_params_struct::KitsuneP2pTuningParams};
 
-use super::{version_manager::VersionManager, HdkVersion, common::{proxy_url, boostrap_service}};
+use super::{version_manager::VersionManager, HdkVersion, HdiVersion, common::{proxy_url, boostrap_service}};
 
 pub struct HolochainV0_0_162;
 
@@ -16,6 +16,11 @@ impl VersionManager for HolochainV0_0_162 {
   // NEW_VERSION: Careful! Indicate here which HDK version comes bundled with this Holochain version
   fn hdk_version(&self) -> HdkVersion {
     HdkVersion::V0_0_152
+  }
+
+  // NEW_VERSION: Careful! Indicate here which HDI version comes bundled with this Holochain version
+  fn hdi_version(&self) -> HdiVersion {
+    HdiVersion::V0_1_2
   }
 
   // NEW_VERSION: Duplicate and change whatever config is necessary to change

--- a/crates/holochain_manager/src/versions/version_manager.rs
+++ b/crates/holochain_manager/src/versions/version_manager.rs
@@ -5,11 +5,13 @@ use enum_dispatch::enum_dispatch;
 use lair_keystore_manager::versions::LairKeystoreVersion;
 use url2::Url2;
 
-use super::HdkVersion;
+use super::{HdkVersion, HdiVersion};
 
 #[enum_dispatch]
 pub trait VersionManager {
   fn hdk_version(&self) -> HdkVersion;
+
+  fn hdi_version(&self) -> HdiVersion;
 
   fn lair_keystore_version(&self) -> LairKeystoreVersion {
     // For now all holochain versions run the same lair keystore version

--- a/src-tauri/src/launcher/default_apps.rs
+++ b/src-tauri/src/launcher/default_apps.rs
@@ -14,8 +14,6 @@ pub async fn install_default_apps_if_necessary(manager: &mut WebAppManager) -> R
 
     let version: String = manager.holochain_manager.version.manager().hdi_version().into();
 
-    log::info!("%*%*%* HDI VERSION: {:?}", version);
-
     let network_seed = if cfg!(debug_assertions) { Some(String::from("launcher-dev")) } else { None };
 
     manager

--- a/src-tauri/src/launcher/default_apps.rs
+++ b/src-tauri/src/launcher/default_apps.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use holochain_manager::versions::holochain_types_latest::web_app::WebAppBundle;
 use holochain_web_app_manager::WebAppManager;
+use holochain_manager::versions::version_manager::VersionManager;
+
 
 pub async fn install_default_apps_if_necessary(manager: &mut WebAppManager) -> Result<(), String> {
   let apps = manager.list_apps().await?;
@@ -10,7 +12,9 @@ pub async fn install_default_apps_if_necessary(manager: &mut WebAppManager) -> R
     let dev_hub_bundle = WebAppBundle::decode(include_bytes!("../../../DevHub.webhapp"))
       .or(Err("Malformed Web hApp bundle file"))?;
 
-    let version: String = manager.holochain_manager.version.into();
+    let version: String = manager.holochain_manager.version.manager().hdi_version().into();
+
+    log::info!("%*%*%* HDI VERSION: {:?}", version);
 
     let network_seed = if cfg!(debug_assertions) { Some(String::from("launcher-dev")) } else { None };
 

--- a/src-tauri/src/launcher/state.rs
+++ b/src-tauri/src/launcher/state.rs
@@ -1,5 +1,5 @@
 use futures::lock::Mutex;
-use holochain_manager::versions::HolochainVersion;
+use holochain_manager::versions::{HolochainVersion, HdiVersion, HdkVersion};
 use holochain_web_app_manager::installed_web_app_info::InstalledWebAppInfo;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc};
@@ -18,6 +18,8 @@ pub struct HolochainInfo {
   pub installed_apps: Vec<InstalledWebAppInfo>,
   pub app_interface_port: u16,
   pub admin_interface_port: u16,
+  pub hdi_version: HdiVersion,
+  pub hdk_version: HdkVersion,
 }
 
 pub type HolochainState = RunningState<HolochainInfo, String>;

--- a/src/components/InstalledAppDetail.vue
+++ b/src/components/InstalledAppDetail.vue
@@ -145,9 +145,9 @@ export default defineComponent({
   },
   methods: {
     isAppUninstallable(installedAppId: string) {
-      const holochainId = this.$store.getters["holochainIdForDevhub"];
+      const hdiVersion = this.$store.getters["hdiOfDevhub"];
 
-      return installedAppId !== `DevHub-${holochainId.content}`;
+      return installedAppId !== `DevHub-${hdiVersion.content}`;
     },
     deserializeHash,
     serializeHash,

--- a/src/components/settings/About.vue
+++ b/src/components/settings/About.vue
@@ -16,7 +16,7 @@
         >
           Holochain v{{ version }}
         </span>
-        <span style="margin-top: 8px"> Lair Keystore v0.2.0 </span>
+        <span style="margin-top: 8px"> Lair Keystore v0.2.1 </span>
       </div>
     </div>
   </mwc-dialog>

--- a/src/hdi.ts
+++ b/src/hdi.ts
@@ -1,0 +1,1 @@
+export type HdiVersion = string;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -135,6 +135,29 @@ export const store = createStore<LauncherAdminState>({
         content: stateInfo.default_version,
       };
     },
+    hdiOfDevhub(state) {
+      const stateInfo = state.launcherStateInfo;
+
+      if (stateInfo === "loading") return undefined;
+
+      const defaultVersion = stateInfo.default_version;
+
+      if (stateInfo.state.content.type === "Running") {
+        const holochainVersions = stateInfo.state.content.content.versions;
+        const devhubHolochainVersion = holochainVersions[defaultVersion];
+        if (devhubHolochainVersion.type === "Running") {
+          return {
+            type: "HdiVersion",
+            content: devhubHolochainVersion.content.hdi_version,
+          };
+        }
+      }
+
+      return {
+        type: "Error",
+        content: "DevHub Holochain version not running.",
+      };
+    },
     setupNeeded(state) {
       if (state.launcherStateInfo === "loading") return undefined;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,11 +23,16 @@ export interface HolochainInfo {
   installed_apps: InstalledWebAppInfo[];
   app_interface_port: number;
   admin_interface_port: number;
+  hdi_version: HdiVersion;
+  hdk_version: HdkVersion;
 }
 
 export type HolochainState = RunningState<HolochainInfo, string>;
 
 export type HolochainVersion = string;
+export type HdkVersion = string;
+export type HdiVersion = string;
+
 export type HolochainId =
   | {
       type: "HolochainVersion";

--- a/src/views/AppStore.vue
+++ b/src/views/AppStore.vue
@@ -132,13 +132,14 @@ export default defineComponent({
 
   async mounted() {
     const holochainId = this.$store.getters["holochainIdForDevhub"];
+    const hdiOfDevhub = this.$store.getters["hdiOfDevhub"];
 
     const port = this.$store.getters["appInterfacePort"](holochainId);
 
     const appWs = await AppWebsocket.connect(`ws://localhost:${port}`);
 
     const devhubInfo = await appWs.appInfo({
-      installed_app_id: `DevHub-${holochainId.content}`,
+      installed_app_id: `DevHub-${hdiOfDevhub.content}`,
     });
 
     let allApps: Array<AppWithReleases>;


### PR DESCRIPTION
This would fix #75. However I feel like we should generally rethink how to organize version compatibility and also maybe add compatibility ranges instead of a 1:1 mapping between holochain version and hdk/hdi version.