### PR TITLE
Validation of pubkeys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3241,6 +3241,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "fs_extra",
+ "futures",
  "holochain_manager",
  "lair_keystore_manager",
  "log",

--- a/crates/holochain_web_app_manager/Cargo.toml
+++ b/crates/holochain_web_app_manager/Cargo.toml
@@ -12,6 +12,7 @@ holochain_manager = {path = "../holochain_manager"}
 lair_keystore_manager = {path = "../lair_keystore_manager"}
 
 fs_extra = "1.2.0"
+futures = "0.3"
 log = "0.4.14"
 portpicker = "0.1.1"
 serde = {version = "1", features = ["derive"]}

--- a/crates/holochain_web_app_manager/src/web_app_manager.rs
+++ b/crates/holochain_web_app_manager/src/web_app_manager.rs
@@ -13,10 +13,11 @@ use holochain_manager::{
 };
 use lair_keystore_manager::utils::create_dir_if_necessary;
 use serde::{Serialize, Deserialize};
+use futures::lock::Mutex;
 use std::{
   collections::HashMap,
   fs::{self, File},
-  path::{Path, PathBuf},
+  path::{Path, PathBuf}, sync::Arc,
 };
 
 use crate::{
@@ -25,8 +26,14 @@ use crate::{
   utils::unzip_file,
 };
 
+
+
+
+
+
 pub struct WebAppManager {
   environment_path: PathBuf,
+  pubkey_map: &'static mut tauri::State<'static, Arc<Mutex<HashMap<String, AgentPubKey>>>>, // mapping of public keys to tauri window label
   pub holochain_manager: HolochainManager,
   allocated_ports: HashMap<String, u16>,
 }
@@ -35,6 +42,7 @@ impl WebAppManager {
   pub async fn launch(
     version: HolochainVersion,
     mut config: LaunchHolochainConfig,
+    pubkey_map: &'static mut tauri::State<'static, Arc<Mutex<HashMap<String, AgentPubKey>>>>,
     password: String,
   ) -> Result<Self, LaunchWebAppManagerError> {
     let environment_path = config.environment_path.clone();
@@ -55,6 +63,7 @@ impl WebAppManager {
     // Fetch the running apps
     let mut manager = WebAppManager {
       holochain_manager,
+      pubkey_map,
       environment_path,
       allocated_ports: HashMap::new(),
     };
@@ -358,6 +367,16 @@ impl WebAppManager {
   pub async fn list_apps(&mut self) -> Result<Vec<InstalledWebAppInfo>, String> {
     let installed_apps = self.holochain_manager.list_apps().await?;
 
+    let mut updated_pubkey_map: HashMap<String, AgentPubKey> = HashMap::new();
+    // update agent public key to tauri window label mapping
+    for app_info in installed_apps.clone() {
+      let holochain_id = self.holochain_manager.version.to_string();
+      let window_label = derive_window_label(&app_info.installed_app_id, &holochain_id);
+      updated_pubkey_map.insert(window_label, app_info.agent_pub_key);
+    }
+
+    *self.pubkey_map.lock().await = updated_pubkey_map;
+
     self.allocate_necessary_ports(&installed_apps);
 
     // Assuming only one single default UI per app at the moment.
@@ -528,6 +547,18 @@ impl WebAppManager {
     }
   }
 
+}
+
+
+/// Derives the window label from the app id and the holochain id
+/// The window label will be of the format [holochain version]#[app id with some special characters removed]
+pub fn derive_window_label(app_id: &String, holochain_id: &String) -> String {
+  // !! it is important to have the window label not be uniquely defined by the app id to ensure
+  // it's possible to unambiguously differentiate this window from the admin window !!
+  let mut window_label: String = holochain_id.to_owned().into();
+  window_label.push_str("#");
+  window_label.push_str(app_id.clone().replace("-", "--").replace(" ", "-").replace(".", "_").as_str());
+  window_label
 }
 
 /// Path to the apps folder relative to a root directory

--- a/src-tauri/src/commands/factory_reset.rs
+++ b/src-tauri/src/commands/factory_reset.rs
@@ -1,4 +1,4 @@
-use std::{fs, io, path::PathBuf};
+use std::{fs, io, path::PathBuf, sync::Arc};
 
 use tauri::{api::process::kill_children, Manager};
 
@@ -123,7 +123,7 @@ pub async fn execute_factory_reset(
 
 
 
-  let manager_launch = LauncherManager::launch(app_handle, profile.clone()).await;
+  let manager_launch = LauncherManager::launch(Arc::new(app_handle), profile.clone()).await;
 
   let mut maybe_error: Option<LauncherError> = None;
 

--- a/src-tauri/src/commands/sign_zome_call.rs
+++ b/src-tauri/src/commands/sign_zome_call.rs
@@ -1,4 +1,8 @@
+use std::collections::HashMap;
+use futures::lock::Mutex;
+use std::sync::Arc;
 use crate::launcher::state::LauncherState;
+use hdk::prelude::AgentPubKey;
 use lair_keystore_manager::*;
 use holochain_types::prelude::ZomeCallUnsigned;
 
@@ -12,6 +16,7 @@ use holochain_launcher_utils::zome_call_signing::ZomeCallUnsignedTauri;
 pub async fn sign_zome_call(
   window: tauri::Window,
   launcher_state: tauri::State<'_, LauncherState>,
+  pubkey_map_state: tauri::State<'_, Arc<Mutex<HashMap<String, AgentPubKey>>>>,
   // state storing the information about what app id is associated with what window label
   // lair_keystore_manager: T<LairKeystoreManager>,
   zome_call_unsigned: ZomeCallUnsignedTauri,
@@ -21,12 +26,27 @@ pub async fn sign_zome_call(
   //   () // this function is allowed to be called in any window
   // }
 
+  let window_label = window.label();
+
   // validate that the agent public key added to the ZomeCallUnsigned field is actually
   // one associated to the UI that's making the call
+  let pubkey_map = &*pubkey_map_state.lock().await;
+  let maybe_authorized_pubkey = pubkey_map.get(window_label);
 
-  // get the agent public key associated to the tauri window that makes the call
-
-
+  if window_label != "admin" {
+    match maybe_authorized_pubkey {
+      Some(pubkey) => {
+        if pubkey != &zome_call_unsigned.provenance {
+          log::warn!("[ZOME CALL SIGNING] WARGNING: A tauri window attempted to make a zome call with a public key that it is not authorized to make zome calls with. Window label: '{}'", window_label);
+          return Err(String::from("The provided public key in the provenance field is not authorized to make a zome call to the requested cell."));
+        }
+      },
+      None => {
+        log::warn!("[ZOME CALL SIGNING] WARGNING: A tauri window attempted to make a zome call with a public key that it is not authorized to make zome calls with. Window label: '{}'", window_label);
+        return Err(String::from("No authorized public key found for this window."));
+      }
+    }
+  }
 
   let zome_call_unsigned_converted: ZomeCallUnsigned = zome_call_unsigned.into();
 
@@ -38,6 +58,6 @@ pub async fn sign_zome_call(
     .await
     .map_err(|_| String::from("Signing zome call failed."))?;
 
-  return Ok(signed_zome_call)
+  Ok(signed_zome_call)
 }
 

--- a/src-tauri/src/commands/sign_zome_call.rs
+++ b/src-tauri/src/commands/sign_zome_call.rs
@@ -5,9 +5,14 @@ use holochain_types::prelude::ZomeCallUnsigned;
 use holochain_launcher_utils::zome_call_signing::ZomeCallUnsignedTauri;
 
 
+// // I need a mapping between window label and agent public key
+// HashMap<String, AgentPubKey> where the string is HolochainVersionId.into::<String>()
+
 #[tauri::command]
 pub async fn sign_zome_call(
-  state: tauri::State<'_, LauncherState>,
+  window: tauri::Window,
+  launcher_state: tauri::State<'_, LauncherState>,
+  // state storing the information about what app id is associated with what window label
   // lair_keystore_manager: T<LairKeystoreManager>,
   zome_call_unsigned: ZomeCallUnsignedTauri,
 ) -> Result<ZomeCall, String> {
@@ -16,9 +21,16 @@ pub async fn sign_zome_call(
   //   () // this function is allowed to be called in any window
   // }
 
+  // validate that the agent public key added to the ZomeCallUnsigned field is actually
+  // one associated to the UI that's making the call
+
+  // get the agent public key associated to the tauri window that makes the call
+
+
+
   let zome_call_unsigned_converted: ZomeCallUnsigned = zome_call_unsigned.into();
 
-  let mut mutex = (*state).lock().await;
+  let mut mutex = (*launcher_state).lock().await;
   let manager = mutex.get_running()?;
 
   let lair_keystore_manager = manager.get_lair_keystore_manager()?;

--- a/src-tauri/src/commands/uninstall_app.rs
+++ b/src-tauri/src/commands/uninstall_app.rs
@@ -25,7 +25,7 @@ pub async fn uninstall_app(
   manager.on_apps_changed().await?;
 
   // close existing window belonging to that app if there is one
-  let window_label = derive_window_label(&app_id, &holochain_id.into());
+  let window_label = derive_window_label(&app_id);
   if let Some(w) = app_handle.get_window(window_label.as_str()) {
     w.close().map_err(|e| format!("Failed to close app window after uninstalling app: {:?}", e))?;
   }

--- a/src-tauri/src/commands/uninstall_app.rs
+++ b/src-tauri/src/commands/uninstall_app.rs
@@ -1,5 +1,6 @@
-use crate::launcher::{state::LauncherState, manager::HolochainId, manager::derive_window_label};
+use crate::launcher::{state::LauncherState, manager::HolochainId};
 use tauri::Manager;
+use holochain_web_app_manager::derive_window_label;
 
 #[tauri::command]
 pub async fn uninstall_app(
@@ -17,14 +18,14 @@ pub async fn uninstall_app(
   let manager = mutex.get_running()?;
 
   manager
-    .get_web_happ_manager(holochain_id)?
+    .get_web_happ_manager(holochain_id.clone())?
     .uninstall_app(app_id.clone())
     .await?;
 
   manager.on_apps_changed().await?;
 
   // close existing window belonging to that app if there is one
-  let window_label = derive_window_label(&app_id);
+  let window_label = derive_window_label(&app_id, &holochain_id.into());
   if let Some(w) = app_handle.get_window(window_label.as_str()) {
     w.close().map_err(|e| format!("Failed to close app window after uninstalling app: {:?}", e))?;
   }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -145,10 +145,10 @@ fn main() {
         .build()?;
 
       // manage the state of pubkeys associated to tauri windows. The keys of this hashmap are window labels
-      let mut pubkey_store: Arc<Mutex<HashMap<String, AgentPubKey>>> = Arc::new(Mutex::new(HashMap::new()));
+      let pubkey_store: Arc<Mutex<HashMap<String, AgentPubKey>>> = Arc::new(Mutex::new(HashMap::new()));
       app.manage(pubkey_store);
 
-      let handle = app.handle().clone();
+      let handle = Arc::new(app.handle());
       let launcher_state =
         tauri::async_runtime::block_on(async move { launch_manager(handle, profile).await });
 
@@ -170,7 +170,7 @@ fn main() {
   }
 }
 
-async fn launch_manager(app_handle: AppHandle, profile: Profile) -> RunningState<LauncherManager, LauncherError> {
+async fn launch_manager(app_handle: Arc<AppHandle>, profile: Profile) -> RunningState<LauncherManager, LauncherError> {
   let holochain_dir = match profile_holochain_data_dir(profile.clone()) {
     Ok(dir) => dir,
     Err(e) => {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,8 +4,10 @@
 )]
 use file_system::{profile_holochain_data_dir, profile_tauri_dir};
 use futures::lock::Mutex;
+use hdk::prelude::AgentPubKey;
 use launcher::error::LauncherError;
 use running_state::RunningState;
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use tauri::AppHandle;
@@ -142,6 +144,9 @@ fn main() {
         .initialization_script("window.__HC_LAUNCHER_ENV__ = {}")
         .build()?;
 
+      // manage the state of pubkeys associated to tauri windows. The keys of this hashmap are window labels
+      let mut pubkey_store: Arc<Mutex<HashMap<String, AgentPubKey>>> = Arc::new(Mutex::new(HashMap::new()));
+      app.manage(pubkey_store);
 
       let handle = app.handle().clone();
       let launcher_state =


### PR DESCRIPTION
This PR introduces validation of pubkeys that request to sign zome calls.

If a request is made by a tauri window to sign a zome call, the Launcher now checks whether the public key specified in the provenance field of this zome call is the correct one, i.e. whether it is the one belonging to the app that this tauri window is associated to. This prevents malicious UI's from being able to make zome calls into cells that they don't belong to.