### PR TITLE
Socket address path length limitation workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 .cargo
 /target
 /test-app
+/default_apps
 
 # temporary files
 .hc*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4150,8 +4150,10 @@ dependencies = [
  "holochain_zome_types",
  "lair_keystore_api",
  "log",
+ "nanoid 0.4.0",
  "serde",
  "serde-enum-str",
+ "symlink",
  "tauri",
  "thiserror",
  "url 2.3.1",
@@ -7333,6 +7335,12 @@ checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"

--- a/crates/lair_keystore_manager/Cargo.toml
+++ b/crates/lair_keystore_manager/Cargo.toml
@@ -18,8 +18,10 @@ holochain_launcher_utils = "0.0.1"
 ascii = "1.0.0"
 async-trait = "0.1.52"
 log = "0.4.14"
+nanoid = "0.4.0"
 serde = {version = "1", features = ["derive"]}
 serde-enum-str = "0.2"
+symlink = "0.1.0"
 tauri = { version = "1.2.3", features = ["process-command-api"]}
 thiserror = "1.0.30"
 url2 = "0.0.6"

--- a/crates/lair_keystore_manager/src/error.rs
+++ b/crates/lair_keystore_manager/src/error.rs
@@ -14,6 +14,12 @@ pub enum LairKeystoreError {
   IncorrectPassword,
   #[error("Failed to create LairClient: `{0}`")]
   ErrorCreatingLairClient(String),
+  #[error("Failed to create temp dir: `{0}`")]
+  ErrorReadingLairConfig(String),
+  #[error("Failed to read lair-keysstore-config.yaml: `{0}`")]
+  ErrorWritingLairConfig(String),
+  #[error("Failed to write lair-keysstore-config.yaml: `{0}`")]
+  ErrorCreatingSimLink(String),
   #[error("Failed to sign zome call: `{0}`")]
   SignZomeCallError(String),
 }

--- a/crates/lair_keystore_manager/src/error.rs
+++ b/crates/lair_keystore_manager/src/error.rs
@@ -20,6 +20,8 @@ pub enum LairKeystoreError {
   ErrorWritingLairConfig(String),
   #[error("Failed to write lair-keysstore-config.yaml: `{0}`")]
   ErrorCreatingSimLink(String),
+  #[error("Lair Keystore Error: `{0}`")]
+  OtherError(String),
   #[error("Failed to sign zome call: `{0}`")]
   SignZomeCallError(String),
 }

--- a/crates/lair_keystore_manager/src/versions/launch.rs
+++ b/crates/lair_keystore_manager/src/versions/launch.rs
@@ -14,13 +14,65 @@ pub async fn launch_lair_keystore_process(
   let mut envs = HashMap::new();
   envs.insert(String::from("RUST_LOG"), String::from(log_level.as_str()));
 
+  let mut keystore_path = keystore_data_dir.clone();
+  println!("### Keystore data dir: {:?}", keystore_path);
+
+  // On Unix systems, there is a limit to the path length of a domain socket. Create a symlink to the lair directory from the tempdir
+  // instead and overwrite the connectionUrl in the lair-keystore-config.yaml
+  if cfg!(target_family="unix") {
+    // let tmp_dir = TempDir::new("lair")
+    //   .map_err(|e| LairKeystoreError::ErrorCreatingTempDir(format!("{}", e)))?;
+    // let tmp_dir_pathbuf = tmp_dir.into_path();
+    let uid = nanoid::nanoid!(13);
+    let src_path = std::env::temp_dir().join(format!("lair.{}", uid));
+    symlink::symlink_dir(keystore_path, src_path.clone())
+      .map_err(|e| LairKeystoreError::ErrorCreatingSimLink(e.to_string()))?;
+    keystore_path = src_path;
+
+    // overwrite connectionUrl in lair-keystore-config.yaml to symlink directory
+    // 1. read to string
+    let mut lair_config_string = std::fs::read_to_string(keystore_path.join("lair-keystore-config.yaml"))
+      .map_err(|e| LairKeystoreError::ErrorReadingLairConfig(e.to_string()))?;
+
+    // 2. filter out the line with the connectionUrl
+    let connection_url_line = lair_config_string.lines().filter(|line| line.contains("connectionUrl:")).collect::<String>();
+
+    // 3. replace the part unix:///home/[user]/.local/share/holochain-launcher/profiles/default/lair/0.2/socket?k=[some_key]
+    //    with unix://[path to tempdir]/socket?k=[some_key]
+    let split_byte_index = connection_url_line.rfind("socket?").unwrap();
+    let socket = &connection_url_line.as_str()[split_byte_index..];
+    let tempdir_connection_url = url::Url::parse(&format!(
+      "unix://{}",
+      keystore_path.join(socket).to_str().unwrap(),
+    )).unwrap();
+
+    let new_line = &format!("connectionUrl: {}\n", tempdir_connection_url);
+
+    // 4. Replace the existing connectionUrl line with that new line
+    lair_config_string = LinesWithEndings::from(lair_config_string.as_str()).map(|line| {
+      if line.contains("connectionUrl:") {
+        new_line
+      } else {
+        line
+      }
+    }).collect::<String>();
+
+    println!("##### REPLACING lair-keystore-config.yaml with: ####\n{}", lair_config_string);
+
+    std::fs::write(keystore_data_dir.join("lair-keystore-config.yaml"), lair_config_string)
+      .map_err(|e| LairKeystoreError::ErrorWritingLairConfig(e.to_string()))?;
+
+  }
+
+
+
   // NEW_VERSION Check whether lair-keystore version needs to get updated
   let (mut lair_rx, mut command_child) = Command::new_sidecar("lair-keystore-v0.2.3")
     .or(Err(LairKeystoreError::LaunchChildError(
       LaunchChildError::BinaryNotFound,
     )))?
     .args(&["server", "-p"])
-    .current_dir(keystore_data_dir.clone())
+    .current_dir(keystore_path.clone())
     .envs(envs.clone())
     .spawn()
     .map_err(|err| {
@@ -74,7 +126,7 @@ pub async fn launch_lair_keystore_process(
       LaunchChildError::BinaryNotFound,
     )))?
     .args(&["url"])
-    .current_dir(keystore_data_dir)
+    .current_dir(keystore_path)
     .envs(envs.clone())
     .output()
     .map_err(|err| {
@@ -92,4 +144,35 @@ pub async fn launch_lair_keystore_process(
   log::info!("Launched lair-keystore");
 
   Ok(url)
+}
+
+
+
+/// Iterator yielding every line in a string. The line includes newline character(s).
+/// https://stackoverflow.com/questions/40455997/iterate-over-lines-in-a-string-including-the-newline-characters
+pub struct LinesWithEndings<'a> {
+  input: &'a str,
+}
+
+impl<'a> LinesWithEndings<'a> {
+  pub fn from(input: &'a str) -> LinesWithEndings<'a> {
+      LinesWithEndings {
+          input: input,
+      }
+  }
+}
+
+impl<'a> Iterator for LinesWithEndings<'a> {
+  type Item = &'a str;
+
+  #[inline]
+  fn next(&mut self) -> Option<&'a str> {
+      if self.input.is_empty() {
+          return None;
+      }
+      let split = self.input.find('\n').map(|i| i + 1).unwrap_or(self.input.len());
+      let (line, rest) = self.input.split_at(split);
+      self.input = rest;
+      Some(line)
+  }
 }

--- a/crates/lair_keystore_manager/src/versions/launch.rs
+++ b/crates/lair_keystore_manager/src/versions/launch.rs
@@ -15,7 +15,6 @@ pub async fn launch_lair_keystore_process(
   envs.insert(String::from("RUST_LOG"), String::from(log_level.as_str()));
 
   let mut keystore_path = keystore_data_dir.clone();
-  println!("### Keystore data dir: {:?}", keystore_path);
 
   // On Unix systems, there is a limit to the path length of a domain socket. Create a symlink to the lair directory from the tempdir
   // instead and overwrite the connectionUrl in the lair-keystore-config.yaml
@@ -56,8 +55,6 @@ pub async fn launch_lair_keystore_process(
         line
       }
     }).collect::<String>();
-
-    println!("##### REPLACING lair-keystore-config.yaml with: ####\n{}", lair_config_string);
 
     std::fs::write(keystore_data_dir.join("lair-keystore-config.yaml"), lair_config_string)
       .map_err(|e| LairKeystoreError::ErrorWritingLairConfig(e.to_string()))?;

--- a/crates/lair_keystore_manager/src/versions/launch.rs
+++ b/crates/lair_keystore_manager/src/versions/launch.rs
@@ -19,9 +19,6 @@ pub async fn launch_lair_keystore_process(
   // On Unix systems, there is a limit to the path length of a domain socket. Create a symlink to the lair directory from the tempdir
   // instead and overwrite the connectionUrl in the lair-keystore-config.yaml
   if cfg!(target_family="unix") {
-    // let tmp_dir = TempDir::new("lair")
-    //   .map_err(|e| LairKeystoreError::ErrorCreatingTempDir(format!("{}", e)))?;
-    // let tmp_dir_pathbuf = tmp_dir.into_path();
     let uid = nanoid::nanoid!(13);
     let src_path = std::env::temp_dir().join(format!("lair.{}", uid));
     symlink::symlink_dir(keystore_path, src_path.clone())


### PR DESCRIPTION
Workaround for #144 . To circumvent the unix domain socket path limitation of around ~100 characters, this PR introduces that on startup of lair, a symlink to the lair directory is created in the temp directory and the connection url in the `lair-keystore-config.yaml` is overwritten with this temporary symlink.