### PR TITLE
added warning dialog when attempting to uninstall devhub

### DIFF
--- a/src/components/AppSettingsCard.vue
+++ b/src/components/AppSettingsCard.vue
@@ -482,9 +482,9 @@ export default defineComponent({
     },
     requestUninstall() {
       if (this.app.webAppInfo.installed_app_info.installed_app_id === DEVHUB_APP_ID) {
-      (this.$refs["uninstall-devhub-dialog"] as typeof HCGenericDialog).open();
+        (this.$refs["uninstall-devhub-dialog"] as typeof HCGenericDialog).open();
       } else {
-      (this.$refs["uninstall-app-dialog"] as typeof HCGenericDialog).open();
+        (this.$refs["uninstall-app-dialog"] as typeof HCGenericDialog).open();
       }
     },
     async enableApp(app: HolochainAppInfo) {

--- a/src/components/AppSettingsCard.vue
+++ b/src/components/AppSettingsCard.vue
@@ -3,9 +3,33 @@
     @confirm="uninstallApp(app)"
     closeOnSideClick
     ref="uninstall-app-dialog"
-    :primaryButtonLabel="$t('buttons.uninstall')"
+    :primaryButtonLabel="uninstalling ? $t('buttons.uninstalling') : $t('buttons.uninstall')"
+    :primaryButtonDisabled="uninstalling"
     ><div style="text-align: center">
       {{ $t('dialogs.confirmUninstallApp') }}
+    </div>
+  </HCGenericDialog>
+
+
+  <HCGenericDialog
+    @confirm="uninstallApp(app);"
+    @closing="confirmUninstallDevHub = false"
+    closeOnSideClick
+    ref="uninstall-devhub-dialog"
+    :primaryButtonLabel="uninstalling ? $t('buttons.uninstalling') : $t('buttons.uninstall')"
+    :primaryButtonDisabled="!confirmUninstallDevHub || uninstalling"
+  >
+    <div style="text-align: center; padding: 0 20px;">
+      <h1 style="margin-top: -10px;">{{ $t('dialogs.warning') }}</h1>
+      <div style="text-align: left; margin-top: 40px;">{{ $t('dialogs.confirmUninstallDevHub.text') }}</div>
+      <div class="row" style="margin-top: 40px; margin-left: 10px;">
+        <ToggleSwitch
+          :sliderOn="confirmUninstallDevHub"
+          @click="confirmUninstallDevHub = !confirmUninstallDevHub"
+          @keydown.enter="confirmUninstallDevHub = !confirmUninstallDevHub"
+        ></ToggleSwitch>
+        <div style="text-align: left; margin-left: 20px;">{{ $t('dialogs.confirmUninstallDevHub.confirmation') }}</div>
+      </div>
     </div>
   </HCGenericDialog>
 
@@ -378,7 +402,7 @@ import HCMoreToggle from "./subcomponents/HCMoreToggle.vue";
 import HCGenericDialog from "./subcomponents/HCGenericDialog.vue";
 import InstalledCellCard from "./subcomponents/InstalledCellCard.vue";
 import DisabledCloneCard from "./subcomponents/DisabledCloneCard.vue";
-import { APPSTORE_APP_ID } from "../constants";
+import { APPSTORE_APP_ID, DEVHUB_APP_ID } from "../constants";
 
 export default defineComponent({
   name: "AppSettingsCard",
@@ -401,22 +425,24 @@ export default defineComponent({
     },
   },
   data(): {
+    confirmUninstallDevHub: boolean;
     showMore: boolean;
-    showUninstallDialog: boolean;
     showPubKeyTooltip: boolean;
     gossipInfo: Record<string, NetworkInfo>;
     showProvisionedCells: boolean;
     showClonedCells: boolean;
     showDisabledClonedCells: boolean;
+    uninstalling: boolean;
   } {
     return {
+      confirmUninstallDevHub: false,
       showMore: false,
-      showUninstallDialog: false,
       showPubKeyTooltip: false,
       gossipInfo: {},
       showProvisionedCells: true,
       showClonedCells: false,
       showDisabledClonedCells: false,
+      uninstalling: false,
     };
   },
   emits: ["openApp", "enableApp", "disableApp", "startApp", "uninstallApp", "updateGui"],
@@ -455,8 +481,11 @@ export default defineComponent({
       return app.webAppInfo.web_uis.default.type === "Headless";
     },
     requestUninstall() {
+      if (this.app.webAppInfo.installed_app_info.installed_app_id === DEVHUB_APP_ID) {
+      (this.$refs["uninstall-devhub-dialog"] as typeof HCGenericDialog).open();
+      } else {
       (this.$refs["uninstall-app-dialog"] as typeof HCGenericDialog).open();
-      this.showUninstallDialog = true;
+      }
     },
     async enableApp(app: HolochainAppInfo) {
       this.$emit("enableApp", app);
@@ -468,8 +497,8 @@ export default defineComponent({
       this.$emit("startApp", app);
     },
     async uninstallApp(app: HolochainAppInfo) {
-      this.showUninstallDialog = false;
       this.$emit("uninstallApp", app);
+      this.uninstalling = true;
     },
     getAppStatus(app: HolochainAppInfo) {
       if (isAppRunning(app.webAppInfo.installed_app_info) || isAppPaused(app.webAppInfo.installed_app_info)) {

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -106,6 +106,7 @@ const messages = {
       save: "Save",
       start: "Start",
       uninstall: "Uninstall",
+      uninstalling: "uninstalling...",
       update: "Update",
       yes: "Yes",
     },
@@ -167,11 +168,16 @@ const messages = {
         languageSettings: "Language Settings",
       },
       confirmUninstallApp: "Are you sure you want to uninstall this App? This will irrevocably delete all data stored in it.",
+      confirmUninstallDevHub: {
+        text: "Uninstalling the DevHub means that you permanently lose editor access to any apps that you have published with this instance of the DevHub (i.e. with the associated public key). This means that you won't be able to publish any further releases or updates to those apps - even if you later reinstall the DevHub.",
+        confirmation: "I read the warning and confirm that I want to uninstall the DevHub."
+      },
       confirmUninstallCell: "Are you sure you want to delete this cell? This will irrevocably delete all data stored in it.",
       networkStats: {
         networkStats: "Network Statistics",
         changeHolochainVersion: "Choose Holochain Version",
       },
+      warning: "Warning",
     },
   },
 
@@ -269,6 +275,7 @@ const messages = {
       save: "Speichern",
       start: "Starten",
       uninstall: "Deinstallieren",
+      uninstalling: "deinstallieren...",
       update: "Update",
       quit: "Beenden",
       yes: "Ja",
@@ -331,11 +338,16 @@ const messages = {
         languageSettings: "Sprach-Einstellungen",
       },
       confirmUninstallApp: "Bist du sicher, dass du diese App deinstallieren möchtest? Dies wird unwiderruflich alle Daten löschen, die darin gespeichert sind.",
+      confirmUninstallDevHub: {
+        text: "Wenn du den DevHub deinstallierst verlierst du unwiderruflich die Bearbeitungsrechte für jegliche Apps die du mit dieser DevHub-Instanz (sprich mit dem dazugehörigen Public Key) publiziert hast. Dies bedeutet, dass du keine weiteren Releases oder Updates für diese Apps mehr publizieren kannst - auch dann, wenn du den DevHub wieder neu installierst.",
+        confirmation: "Ich habe die Warning gelesen und bestätige, dass ich den DevHub deinstallieren möchte."
+      },
       confirmUninstallCell: "Bist du sicher, dass du diese Cell deinstallieren möchtest? Dies wird unwiderruflich alle Daten löschen, die darin gespeichert sind.",
       networkStats: {
         networkStats: "Netzwerkstatistik",
         changeHolochainVersion: "Holochain Version",
       },
+      warning: "Achtung",
     },
   },
 };


### PR DESCRIPTION
Adds a warning dialog when attempting to uninstall the DevHub because this causes permanent loss of editor rights of apps published with this DevHub instance.