### PR TITLE
move holochain dependencies to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,23 @@ members = [
 ]
 resolver = "2"
 
+[workspace.dependencies]
+# NEW_VERSION Update holochain dependencies here
+holochain = { version = "0.2.2", features = ["sqlite-encrypted"] }
+holochain_cli_sandbox = "0.2.2"
+holochain_types = "0.2.2"
+holochain_util = { version = "0.2.2", features = [ "pw" ] }
+holochain_zome_types = "0.2.2"
+holochain_conductor_api = "0.2.2"
+holochain_trace = "0.2.2"
+holochain_state = "0.2.2"
+
+hdk = "0.2.2"
+
+holochain_client = "0.4.2"
+
+lair_keystore_api = "0.3.0"
+
+mr_bundle = "0.2.2"
+
+devhub_types = { git = "https://github.com/mrruby/devhub-dnas" }

--- a/crates/hc_launch/src-tauri/Cargo.toml
+++ b/crates/hc_launch/src-tauri/Cargo.toml
@@ -23,20 +23,19 @@ tauri-build = { version = "1.4.0", features = [] }
 anyhow = "1.0"
 futures = "0.3"
 
-# NEW_VERSION update holochain dependencies
-holochain_client = "0.4.2"
-holochain_cli_sandbox = "0.2.2"
+
+holochain_client = { workspace = true }
+holochain_cli_sandbox =  { workspace = true }
 holochain_launcher_utils = { path = "../../holochain_launcher_utils" }
-holochain_types = "0.2.2"
-holochain_util = { version = "0.2.2", features = [ "pw" ] }
-holochain_zome_types = "0.2.2"
-holochain_conductor_api = "0.2.2"
-holochain_trace = "0.2.2"
+holochain_types =  { workspace = true }
+holochain_util = { workspace = true }
+holochain_zome_types = { workspace = true }
+holochain_conductor_api = { workspace = true }
+holochain_trace = { workspace = true }
 
-holochain = { version = "0.2.2", features = ["sqlite-encrypted"] }
+holochain = { workspace = true }
 
-
-lair_keystore_api = "0.3.0"
+lair_keystore_api = { workspace = true }
 
 
 clap = { version = "4.0", features = [ "derive", "env" ] }

--- a/crates/holochain_launcher_utils/Cargo.toml
+++ b/crates/holochain_launcher_utils/Cargo.toml
@@ -13,14 +13,13 @@ categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 
-# NEW_VERSION update holochain dependencies
-holochain_client = "0.4.2"
+holochain_client = { workspace = true }
 
-holochain_conductor_api = "0.2.2"
-holochain_types = "0.2.2"
-holochain_zome_types = "0.2.2"
+holochain_conductor_api = { workspace = true }
+holochain_types = { workspace = true }
+holochain_zome_types = { workspace = true }
 
-lair_keystore_api = "0.3.0"
+lair_keystore_api = { workspace = true }
 
 
 log = "0.4.14"

--- a/crates/holochain_manager/Cargo.toml
+++ b/crates/holochain_manager/Cargo.toml
@@ -8,17 +8,16 @@ version = "0.1.0"
 [dependencies]
 # NEW_VERSION pick right client version
 
-holochain = { version = "0.2.2", features = ["sqlite-encrypted"] }
-holochain_client = "0.4.2"
+holochain = { workspace = true }
+holochain_client = { workspace = true }
 
 
 # NEW_VERSION add latest crates here
-
 holochain_conductor_api_0_2_2 = { package = "holochain_conductor_api", version = "0.2.2" }
 holochain_p2p_0_2_2 = { package = "holochain_p2p", version = "0.2.2" }
 holochain_types_0_2_2 = { package = "holochain_types", version = "0.2.2" }
 
-mr_bundle = "0.2.2"
+mr_bundle = { workspace = true }
 
 lair_keystore_manager = {path = "../lair_keystore_manager"}
 

--- a/crates/lair_keystore_manager/Cargo.toml
+++ b/crates/lair_keystore_manager/Cargo.toml
@@ -8,10 +8,10 @@ version = "0.1.0"
 [dependencies]
 
 # NEW_VERSION update holochain_types, holochain_zome_types and holochain_conductor_api here and if necessary also lair_keystore_api
-lair_keystore_api = "0.3.0"
-holochain_conductor_api = "0.2.2"
-holochain_types = "0.2.2"
-holochain_zome_types = "0.2.2"
+lair_keystore_api = { workspace = true }
+holochain_conductor_api = { workspace = true }
+holochain_types = { workspace = true }
+holochain_zome_types = { workspace = true }
 
 holochain_launcher_utils = { path = "../holochain_launcher_utils" }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ tauri-build = { version = "1.4.0", features = [] }
 [dependencies]
 
 # NEW_VERSION update holochain client version if requireds
-holochain_client = "0.4.2"
+holochain_client = { workspace = true }
 
 holochain_manager = { path = "../crates/holochain_manager" }
 holochain_launcher_utils = { path = "../crates/holochain_launcher_utils" }
@@ -26,15 +26,16 @@ holochain_web_app_manager = { path = "../crates/holochain_web_app_manager" }
 lair_keystore_manager = { path = "../crates/lair_keystore_manager" }
 
 # NEW_VERSION update holochain dependencies
-holochain_types = "0.2.2"
-holochain_state = "0.2.2"
-hdk = "0.2.2"
+holochain_types = { workspace = true }
+holochain_state = { workspace = true }
+hdk = { workspace = true }
 
-holochain = { version = "0.2.2", features = ["sqlite-encrypted"] }
+holochain = { workspace = true }
 
-mr_bundle = "0.2.2"
+mr_bundle = { workspace = true }
 
-devhub_types = { git = "https://github.com/mrruby/devhub-dnas" }
+devhub_types = { workspace = true }
+
 
 
 async-recursion = "1.0.4"


### PR DESCRIPTION
This PR moves most of the holochain dependencies into the workspace Cargo.toml file which should make it much easier to bump holochain versions.