### PR TITLE
Bump weekly 0.3 32

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,9 +42,9 @@ jobs:
           Copy-Item $LkPath -Destination src-tauri/bins/lair-keystore-v0.3.0-x86_64-pc-windows-msvc.exe
 
 
-          cargo install holochain --version 0.3.0-beta-dev.25 --features sqlite-encrypted
+          cargo install holochain --version 0.3.0-beta-dev.34
           $HcPath = Get-Command holochain | Select-Object -ExpandProperty Definition
-          Copy-Item $HcPath -Destination src-tauri/bins/holochain-v0.3.0-beta-dev.25-x86_64-pc-windows-msvc.exe
+          Copy-Item $HcPath -Destination src-tauri/bins/holochain-v0.3.0-beta-dev.34-x86_64-pc-windows-msvc.exe
 
           # NEW_VERSION: install new holochain version and copy its binary to the tauri path
 
@@ -57,9 +57,9 @@ jobs:
           LAIR_PATH=$(which lair-keystore)
           cp $LAIR_PATH src-tauri/bins/lair-keystore-v0.3.0-x86_64-apple-darwin
 
-          cargo install holochain --version 0.3.0-beta-dev.25 --features sqlite-encrypted
+          cargo install holochain --version 0.3.0-beta-dev.34
           HOLOCHAIN_PATH=$(which holochain)
-          cp $HOLOCHAIN_PATH src-tauri/bins/holochain-v0.3.0-beta-dev.25-x86_64-apple-darwin
+          cp $HOLOCHAIN_PATH src-tauri/bins/holochain-v0.3.0-beta-dev.34-x86_64-apple-darwin
 
           # NEW_VERSION: install new holochain version and copy its binary to the tauri path
 
@@ -79,9 +79,9 @@ jobs:
           cp $LAIR_PATH src-tauri/bins/lair-keystore-v0.3.0-x86_64-unknown-linux-gnu
 
 
-          cargo install holochain --version 0.3.0-beta-dev.25 --features sqlite-encrypted
+          cargo install holochain --version 0.3.0-beta-dev.34
           HOLOCHAIN_PATH=$(which holochain)
-          cp $HOLOCHAIN_PATH src-tauri/bins/holochain-v0.3.0-beta-dev.25-x86_64-unknown-linux-gnu
+          cp $HOLOCHAIN_PATH src-tauri/bins/holochain-v0.3.0-beta-dev.34-x86_64-unknown-linux-gnu
 
 
           # NEW_VERSION: install new holochain version and copy its binary to the tauri path

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,9 +39,9 @@ jobs:
           cp $LAIR_PATH src-tauri/bins/lair-keystore-v0.3.0-x86_64-unknown-linux-gnu
 
 
-          cargo install holochain --version 0.3.0-beta-dev.25 --features sqlite-encrypted
+          cargo install holochain --version 0.3.0-beta-dev.34
           HOLOCHAIN_PATH=$(which holochain)
-          cp $HOLOCHAIN_PATH src-tauri/bins/holochain-v0.3.0-beta-dev.25-x86_64-unknown-linux-gnu
+          cp $HOLOCHAIN_PATH src-tauri/bins/holochain-v0.3.0-beta-dev.34-x86_64-unknown-linux-gnu
 
 
           # NEW_VERSION: install new holochain version and copy its binary to the tauri path

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "aitia"
+version = "0.1.0"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "holochain_trace 0.3.0-beta-dev.5",
+ "parking_lot 0.10.2",
+ "petgraph",
+ "regex",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-core",
+ "tracing-serde",
+ "tracing-subscriber 0.3.17",
+]
+
+[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,7 +1691,7 @@ dependencies = [
  "essence_payloads",
  "flate2",
  "hc_crud_caps",
- "hdk",
+ "hdk 0.3.0-beta-dev.26",
  "hex",
  "rmp-serde 0.15.5",
  "serde",
@@ -2114,6 +2133,22 @@ name = "fixt"
 version = "0.3.0-beta-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15eb8dc36476da0d07a264766fba94be61ad66a52f05cadb82453ef723465de9"
+dependencies = [
+ "holochain_serialized_bytes",
+ "lazy_static",
+ "parking_lot 0.10.2",
+ "paste",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "serde",
+ "strum 0.18.0",
+ "strum_macros 0.18.0",
+]
+
+[[package]]
+name = "fixt"
+version = "0.3.0-beta-dev.0"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -2821,8 +2856,8 @@ name = "hc_crud_caps"
 version = "0.9.1"
 source = "git+https://github.com/matthme/rust-hc-crud-caps?branch=holochain-0.3.0-beta-dev.20#24fe3f997de86c72f71f5653f3f1d6239a137386"
 dependencies = [
- "hdk",
- "holo_hash",
+ "hdk 0.3.0-beta-dev.26",
+ "holo_hash 0.3.0-beta-dev.18",
  "serde",
  "thiserror",
 ]
@@ -2843,14 +2878,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "hdi"
-version = "0.4.0-beta-dev.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740377f57fcc5ba4913f3836ba87208ddb1153b8e11bede7a6aae0b86e54d088"
+name = "hc_sleuth"
+version = "0.1.0"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
- "hdk_derive",
- "holo_hash",
- "holochain_integrity_types",
+ "aitia",
+ "anyhow",
+ "derive_more",
+ "holochain_state_types 0.3.0-beta-dev.26",
+ "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_types 0.3.0-beta-dev.26",
+ "kitsune_p2p 0.3.0-beta-dev.25",
+ "once_cell",
+ "parking_lot 0.10.2",
+ "petgraph",
+ "regex",
+ "serde",
+ "structopt",
+ "tracing",
+ "tracing-subscriber 0.3.17",
+]
+
+[[package]]
+name = "hdi"
+version = "0.4.0-beta-dev.20"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+dependencies = [
+ "hdk_derive 0.3.0-beta-dev.19",
+ "holo_hash 0.3.0-beta-dev.16",
+ "holochain_integrity_types 0.3.0-beta-dev.19",
+ "holochain_wasmer_guest",
+ "paste",
+ "serde",
+ "serde_bytes",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "hdi"
+version = "0.4.0-beta-dev.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c50adb6a522c18234160667d348325e9ebd880048ac79a09925443d31c5f6ad"
+dependencies = [
+ "hdk_derive 0.3.0-beta-dev.21",
+ "holo_hash 0.3.0-beta-dev.18",
+ "holochain_integrity_types 0.3.0-beta-dev.21",
  "holochain_wasmer_guest",
  "paste",
  "serde",
@@ -2861,16 +2934,35 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.3.0-beta-dev.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c140edcaedc44e94b768868101a6a7614100338666525c51fc32bdea15e74fe"
+version = "0.3.0-beta-dev.24"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "getrandom 0.2.7",
- "hdi",
- "hdk_derive",
- "holo_hash",
+ "hdi 0.4.0-beta-dev.20",
+ "hdk_derive 0.3.0-beta-dev.19",
+ "holo_hash 0.3.0-beta-dev.16",
  "holochain_wasmer_guest",
- "holochain_zome_types",
+ "holochain_zome_types 0.3.0-beta-dev.20",
+ "paste",
+ "serde",
+ "serde_bytes",
+ "thiserror",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "hdk"
+version = "0.3.0-beta-dev.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d602a52411cd1136d6858ed87d13bc362f2a24f39ba2ae22d2405a2f5283d64"
+dependencies = [
+ "getrandom 0.2.7",
+ "hdi 0.4.0-beta-dev.22",
+ "hdk_derive 0.3.0-beta-dev.21",
+ "holo_hash 0.3.0-beta-dev.18",
+ "holochain_wasmer_guest",
+ "holochain_zome_types 0.3.0-beta-dev.22",
  "paste",
  "serde",
  "serde_bytes",
@@ -2881,13 +2973,28 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.3.0-beta-dev.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3e2bb8b9b259eb7f83397d442fba4200ccb56a4f09a10d10e360f47ddf7852"
+version = "0.3.0-beta-dev.19"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "darling 0.14.4",
  "heck 0.4.1",
- "holochain_integrity_types",
+ "holochain_integrity_types 0.3.0-beta-dev.19",
+ "paste",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "hdk_derive"
+version = "0.3.0-beta-dev.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ec48bc0fe3e785b238cd097e295ff66c714bc9cf0f91bcc552482446c5e00a"
+dependencies = [
+ "darling 0.14.4",
+ "heck 0.4.1",
+ "holochain_integrity_types 0.3.0-beta-dev.21",
  "paste",
  "proc-macro-error",
  "proc-macro2",
@@ -2972,19 +3079,41 @@ dependencies = [
 
 [[package]]
 name = "holo_hash"
-version = "0.3.0-beta-dev.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082c1315aaa2cff186d36f0fbb351e1963a28e1e1719c4dd01404c2282cbbb96"
+version = "0.3.0-beta-dev.16"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "base64 0.13.1",
  "blake2b_simd 0.5.11",
  "derive_more",
- "fixt",
+ "fixt 0.3.0-beta-dev.0 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "futures",
  "holochain_serialized_bytes",
- "holochain_util",
+ "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "holochain_wasmer_common",
- "kitsune_p2p_dht_arc",
+ "kitsune_p2p_dht_arc 0.3.0-beta-dev.10",
+ "must_future",
+ "rand 0.8.5",
+ "rusqlite",
+ "serde",
+ "serde_bytes",
+ "thiserror",
+]
+
+[[package]]
+name = "holo_hash"
+version = "0.3.0-beta-dev.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc9782dc9476547677610bab509815cea2512588026ed9f0b695c0749bc04e3a"
+dependencies = [
+ "base64 0.13.1",
+ "blake2b_simd 0.5.11",
+ "derive_more",
+ "fixt 0.3.0-beta-dev.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "holochain_serialized_bytes",
+ "holochain_util 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_wasmer_common",
+ "kitsune_p2p_dht_arc 0.3.0-beta-dev.12",
  "must_future",
  "rand 0.8.5",
  "rusqlite",
@@ -2995,10 +3124,10 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.3.0-beta-dev.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11651699a6ee248799753df8076608bb07cf2ca9aeb53c5d873c625d1a361049"
+version = "0.3.0-beta-dev.29"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
+ "aitia",
  "anyhow",
  "async-once-cell",
  "async-recursion 0.3.2",
@@ -3012,42 +3141,44 @@ dependencies = [
  "directories",
  "either",
  "fallible-iterator",
- "fixt",
+ "fixt 0.3.0-beta-dev.0 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "futures",
  "get_if_addrs",
  "getrandom 0.2.7",
  "ghost_actor 0.3.0-alpha.6",
- "hdk",
- "holo_hash",
+ "hc_sleuth",
+ "hdk 0.3.0-beta-dev.24",
+ "holo_hash 0.3.0-beta-dev.16",
  "holochain_cascade",
- "holochain_conductor_api",
- "holochain_keystore",
+ "holochain_conductor_api 0.3.0-beta-dev.29",
+ "holochain_keystore 0.3.0-beta-dev.21",
  "holochain_metrics",
- "holochain_nonce",
+ "holochain_nonce 0.3.0-beta-dev.22 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "holochain_p2p",
- "holochain_secure_primitive",
+ "holochain_secure_primitive 0.3.0-beta-dev.21 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "holochain_serialized_bytes",
- "holochain_sqlite",
+ "holochain_services",
+ "holochain_sqlite 0.3.0-beta-dev.26",
  "holochain_state",
- "holochain_trace",
- "holochain_types",
- "holochain_util",
+ "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_types 0.3.0-beta-dev.26",
+ "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "holochain_wasm_test_utils",
  "holochain_wasmer_host",
- "holochain_websocket",
- "holochain_zome_types",
+ "holochain_websocket 0.3.0-beta-dev.6",
+ "holochain_zome_types 0.3.0-beta-dev.20",
  "hostname",
  "human-panic",
  "itertools 0.10.5",
- "kitsune_p2p",
- "kitsune_p2p_bin_data",
- "kitsune_p2p_block",
- "kitsune_p2p_bootstrap",
- "kitsune_p2p_bootstrap_client",
- "kitsune_p2p_types",
+ "kitsune_p2p 0.3.0-beta-dev.25",
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
+ "kitsune_p2p_block 0.3.0-beta-dev.13",
+ "kitsune_p2p_bootstrap 0.2.0-beta-dev.16",
+ "kitsune_p2p_bootstrap_client 0.3.0-beta-dev.22",
+ "kitsune_p2p_types 0.3.0-beta-dev.16",
  "lazy_static",
  "mockall",
- "mr_bundle",
+ "mr_bundle 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "must_future",
  "nanoid 0.3.0",
  "num_cpus",
@@ -3102,21 +3233,21 @@ dependencies = [
  "devhub_types",
  "dirs-next",
  "futures",
- "hdk",
+ "hdk 0.3.0-beta-dev.24",
  "holochain",
  "holochain_client",
  "holochain_launcher_utils",
  "holochain_manager",
- "holochain_nonce",
+ "holochain_nonce 0.3.0-beta-dev.22 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "holochain_state",
- "holochain_types",
+ "holochain_types 0.3.0-beta-dev.26",
  "holochain_web_app_manager",
  "lair_keystore_manager",
  "log",
  "log4rs",
  "mere_memory_types",
  "mime_guess",
- "mr_bundle",
+ "mr_bundle 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "open 5.0.0",
  "opener",
  "portpicker",
@@ -3134,30 +3265,29 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.3.0-beta-dev.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ac67b939ab28e661e48e37d5327035684517cd8f94720a2188d7c91bcbc9cc"
+version = "0.3.0-beta-dev.29"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "async-trait",
  "derive_more",
  "either",
  "fallible-iterator",
- "fixt",
+ "fixt 0.3.0-beta-dev.0 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "futures",
  "ghost_actor 0.3.0-alpha.6",
- "hdk",
- "hdk_derive",
- "holo_hash",
- "holochain_nonce",
+ "hdk 0.3.0-beta-dev.24",
+ "hdk_derive 0.3.0-beta-dev.19",
+ "holo_hash 0.3.0-beta-dev.16",
+ "holochain_nonce 0.3.0-beta-dev.22 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "holochain_p2p",
  "holochain_serialized_bytes",
- "holochain_sqlite",
+ "holochain_sqlite 0.3.0-beta-dev.26",
  "holochain_state",
- "holochain_trace",
- "holochain_types",
- "holochain_util",
- "holochain_zome_types",
- "kitsune_p2p",
+ "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_types 0.3.0-beta-dev.26",
+ "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "holochain_zome_types 0.3.0-beta-dev.20",
+ "kitsune_p2p 0.3.0-beta-dev.25",
  "once_cell",
  "opentelemetry_api",
  "serde",
@@ -3178,12 +3308,12 @@ dependencies = [
  "holochain",
  "holochain_cli_sandbox",
  "holochain_client",
- "holochain_conductor_api",
+ "holochain_conductor_api 0.3.0-beta-dev.29",
  "holochain_launcher_utils",
- "holochain_trace",
- "holochain_types",
- "holochain_util",
- "holochain_zome_types",
+ "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_types 0.3.0-beta-dev.26",
+ "holochain_util 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_zome_types 0.3.0-beta-dev.20",
  "lair_keystore_api",
  "log",
  "mime_guess",
@@ -3205,22 +3335,21 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_sandbox"
-version = "0.3.0-beta-dev.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c69e0f7ceac94629dd7a122beab3510cebfd92f799ffe54c70b7200b4f7a711"
+version = "0.3.0-beta-dev.29"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "ansi_term",
  "anyhow",
  "chrono",
  "clap 4.4.8",
  "futures",
- "holochain_conductor_api",
+ "holochain_conductor_api 0.3.0-beta-dev.29",
  "holochain_p2p",
- "holochain_trace",
- "holochain_types",
- "holochain_util",
- "holochain_websocket",
- "kitsune_p2p_types",
+ "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_types 0.3.0-beta-dev.26",
+ "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "holochain_websocket 0.3.0-beta-dev.6",
+ "kitsune_p2p_types 0.3.0-beta-dev.16",
  "nanoid 0.3.0",
  "once_cell",
  "serde",
@@ -3243,35 +3372,61 @@ dependencies = [
  "anyhow",
  "ed25519-dalek",
  "getrandom 0.2.7",
- "holo_hash",
- "holochain_conductor_api",
+ "holo_hash 0.3.0-beta-dev.18",
+ "holochain_conductor_api 0.3.0-beta-dev.31",
  "holochain_serialized_bytes",
- "holochain_types",
- "holochain_websocket",
- "holochain_zome_types",
+ "holochain_types 0.3.0-beta-dev.28",
+ "holochain_websocket 0.3.0-beta-dev.8",
+ "holochain_zome_types 0.3.0-beta-dev.22",
  "serde",
  "url 2.4.1",
 ]
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.3.0-beta-dev.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68e4dffe9fe1b36d8db3eeb1e272e699d5e6f9f34e6b3ddc16cadbda8fa67db"
+version = "0.3.0-beta-dev.29"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "derive_more",
  "directories",
- "holo_hash",
- "holochain_keystore",
+ "holo_hash 0.3.0-beta-dev.16",
+ "holochain_keystore 0.3.0-beta-dev.21",
  "holochain_serialized_bytes",
- "holochain_state_types",
- "holochain_types",
- "holochain_zome_types",
- "kitsune_p2p_bin_data",
- "kitsune_p2p_types",
+ "holochain_state_types 0.3.0-beta-dev.26",
+ "holochain_types 0.3.0-beta-dev.26",
+ "holochain_zome_types 0.3.0-beta-dev.20",
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
+ "kitsune_p2p_types 0.3.0-beta-dev.16",
  "serde",
  "serde_derive",
  "serde_yaml 0.9.25",
+ "shrinkwraprs",
+ "structopt",
+ "thiserror",
+ "tracing",
+ "url2",
+]
+
+[[package]]
+name = "holochain_conductor_api"
+version = "0.3.0-beta-dev.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b853065ade656c6c94ab2175d42f0759e2d06adb2604b9b11ac2ca392cff928b"
+dependencies = [
+ "derive_more",
+ "directories",
+ "holo_hash 0.3.0-beta-dev.18",
+ "holochain_keystore 0.3.0-beta-dev.23",
+ "holochain_serialized_bytes",
+ "holochain_state_types 0.3.0-beta-dev.28",
+ "holochain_types 0.3.0-beta-dev.28",
+ "holochain_zome_types 0.3.0-beta-dev.22",
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.13",
+ "kitsune_p2p_types 0.3.0-beta-dev.18",
+ "serde",
+ "serde_derive",
+ "serde_yaml 0.9.25",
+ "shrinkwraprs",
  "structopt",
  "thiserror",
  "tracing",
@@ -3280,16 +3435,35 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.3.0-beta-dev.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449d67afe83b910764d09362dac8d90b5172a9945693d29c991f1657ec21def3"
+version = "0.3.0-beta-dev.19"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "derive_builder",
- "holo_hash",
- "holochain_secure_primitive",
+ "holo_hash 0.3.0-beta-dev.16",
+ "holochain_secure_primitive 0.3.0-beta-dev.21 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "holochain_serialized_bytes",
- "holochain_util",
- "kitsune_p2p_timestamp",
+ "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "paste",
+ "serde",
+ "serde_bytes",
+ "subtle",
+ "subtle-encoding",
+ "tracing",
+]
+
+[[package]]
+name = "holochain_integrity_types"
+version = "0.3.0-beta-dev.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19774dd65cf49fd1cb780b0581f5592ca32ca907cc56562abfc9c5ca1492ef7"
+dependencies = [
+ "derive_builder",
+ "holo_hash 0.3.0-beta-dev.18",
+ "holochain_secure_primitive 0.3.0-beta-dev.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_serialized_bytes",
+ "holochain_util 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste",
  "serde",
  "serde_bytes",
@@ -3300,18 +3474,18 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.3.0-beta-dev.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2239fabec313607d37cec05521151322df2bd3df5ec1e5214ba62d24118ff560"
+version = "0.3.0-beta-dev.21"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "base64 0.13.1",
+ "derive_more",
  "futures",
- "holo_hash",
- "holochain_secure_primitive",
+ "holo_hash 0.3.0-beta-dev.16",
+ "holochain_secure_primitive 0.3.0-beta-dev.21 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "holochain_serialized_bytes",
- "holochain_util",
- "holochain_zome_types",
- "kitsune_p2p_types",
+ "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "holochain_zome_types 0.3.0-beta-dev.20",
+ "kitsune_p2p_types 0.3.0-beta-dev.16",
  "lair_keystore",
  "must_future",
  "nanoid 0.4.0",
@@ -3319,6 +3493,36 @@ dependencies = [
  "parking_lot 0.11.2",
  "serde",
  "serde_bytes",
+ "shrinkwraprs",
+ "sodoken",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "holochain_keystore"
+version = "0.3.0-beta-dev.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36cea01831221bf2630daf924870237cfc4a3dae96f13aea2cc01bece7e76ca"
+dependencies = [
+ "base64 0.13.1",
+ "derive_more",
+ "futures",
+ "holo_hash 0.3.0-beta-dev.18",
+ "holochain_secure_primitive 0.3.0-beta-dev.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_serialized_bytes",
+ "holochain_util 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_zome_types 0.3.0-beta-dev.22",
+ "kitsune_p2p_types 0.3.0-beta-dev.18",
+ "lair_keystore",
+ "must_future",
+ "nanoid 0.4.0",
+ "one_err",
+ "parking_lot 0.11.2",
+ "serde",
+ "serde_bytes",
+ "shrinkwraprs",
  "sodoken",
  "thiserror",
  "tokio",
@@ -3330,9 +3534,9 @@ name = "holochain_launcher_utils"
 version = "0.0.5"
 dependencies = [
  "holochain_client",
- "holochain_conductor_api",
- "holochain_types",
- "holochain_zome_types",
+ "holochain_conductor_api 0.3.0-beta-dev.29",
+ "holochain_types 0.3.0-beta-dev.26",
+ "holochain_zome_types 0.3.0-beta-dev.20",
  "lair_keystore_api",
  "log",
  "mime_guess",
@@ -3350,12 +3554,12 @@ dependencies = [
  "enum_dispatch",
  "holochain",
  "holochain_client",
- "holochain_conductor_api",
+ "holochain_conductor_api 0.3.0-beta-dev.29",
  "holochain_p2p",
- "holochain_types",
+ "holochain_types 0.3.0-beta-dev.26",
  "lair_keystore_manager",
  "log",
- "mr_bundle",
+ "mr_bundle 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "portpicker",
  "serde",
  "serde-enum-str",
@@ -3370,8 +3574,7 @@ dependencies = [
 [[package]]
 name = "holochain_metrics"
 version = "0.3.0-beta-dev.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1be17104fab1e58a94c3679b890ba1221c68d15ce1626a8c4e6da026b363a6"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "influxive",
  "opentelemetry_api",
@@ -3387,31 +3590,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aca92634944f023be0808df98bfc8f484b6f23f0f1452197043f287e06511e6c"
 dependencies = [
  "getrandom 0.2.7",
- "holochain_secure_primitive",
- "kitsune_p2p_timestamp",
+ "holochain_secure_primitive 0.3.0-beta-dev.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "holochain_nonce"
+version = "0.3.0-beta-dev.22"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+dependencies = [
+ "getrandom 0.2.7",
+ "holochain_secure_primitive 0.3.0-beta-dev.21 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
 ]
 
 [[package]]
 name = "holochain_p2p"
-version = "0.3.0-beta-dev.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc077d1c0745f9e377b8256bb5a90b492b4dc9e47ba1ad8de1a25af88809278c"
+version = "0.3.0-beta-dev.28"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
+ "aitia",
  "async-trait",
  "derive_more",
- "fixt",
+ "fixt 0.3.0-beta-dev.0 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "futures",
  "ghost_actor 0.3.0-alpha.6",
- "holo_hash",
- "holochain_keystore",
- "holochain_nonce",
+ "hc_sleuth",
+ "holo_hash 0.3.0-beta-dev.16",
+ "holochain_keystore 0.3.0-beta-dev.21",
+ "holochain_nonce 0.3.0-beta-dev.22 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "holochain_serialized_bytes",
- "holochain_trace",
- "holochain_types",
- "holochain_util",
- "holochain_zome_types",
- "kitsune_p2p",
- "kitsune_p2p_types",
+ "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_types 0.3.0-beta-dev.26",
+ "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "holochain_zome_types 0.3.0-beta-dev.20",
+ "kitsune_p2p 0.3.0-beta-dev.25",
+ "kitsune_p2p_types 0.3.0-beta-dev.16",
  "mockall",
  "rand 0.8.5",
  "serde",
@@ -3427,6 +3641,16 @@ name = "holochain_secure_primitive"
 version = "0.3.0-beta-dev.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ae856ba625c5609e536456461463d13607eda623f7cc4e4b3a54dbb43ac052"
+dependencies = [
+ "paste",
+ "serde",
+ "subtle",
+]
+
+[[package]]
+name = "holochain_secure_primitive"
+version = "0.3.0-beta-dev.21"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "paste",
  "serde",
@@ -3459,10 +3683,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "holochain_services"
+version = "0.2.0-beta-dev.0"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "derive_more",
+ "futures",
+ "holochain_keystore 0.3.0-beta-dev.21",
+ "holochain_types 0.3.0-beta-dev.26",
+ "mockall",
+ "must_future",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "holochain_sqlite"
-version = "0.3.0-beta-dev.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef64effd99941aba5eff30c67792f68f8ee9c54752aaba1a3e568eb572b098b8"
+version = "0.3.0-beta-dev.26"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3471,22 +3711,67 @@ dependencies = [
  "fallible-iterator",
  "futures",
  "getrandom 0.2.7",
- "holo_hash",
- "holochain_nonce",
+ "holo_hash 0.3.0-beta-dev.16",
+ "holochain_nonce 0.3.0-beta-dev.22 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "holochain_serialized_bytes",
- "holochain_util",
- "holochain_zome_types",
- "kitsune_p2p",
- "kitsune_p2p_bin_data",
- "kitsune_p2p_dht",
- "kitsune_p2p_dht_arc",
- "kitsune_p2p_timestamp",
- "kitsune_p2p_types",
+ "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "holochain_zome_types 0.3.0-beta-dev.20",
+ "kitsune_p2p 0.3.0-beta-dev.25",
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
+ "kitsune_p2p_dht 0.3.0-beta-dev.12",
+ "kitsune_p2p_dht_arc 0.3.0-beta-dev.10",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "kitsune_p2p_types 0.3.0-beta-dev.16",
  "num_cpus",
  "once_cell",
  "opentelemetry_api",
  "parking_lot 0.10.2",
- "pretty_assertions 0.7.2",
+ "pretty_assertions",
+ "r2d2",
+ "r2d2_sqlite_neonphog",
+ "rmp-serde 0.15.5",
+ "rusqlite",
+ "scheduled-thread-pool",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "shrinkwraprs",
+ "sqlformat 0.1.8",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "holochain_sqlite"
+version = "0.3.0-beta-dev.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c55f32f311090b7d447f3e22973708aa3b092e58a86250e26a399e16ed6582"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chashmap",
+ "derive_more",
+ "fallible-iterator",
+ "futures",
+ "getrandom 0.2.7",
+ "holo_hash 0.3.0-beta-dev.18",
+ "holochain_nonce 0.3.0-beta-dev.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_serialized_bytes",
+ "holochain_util 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_zome_types 0.3.0-beta-dev.22",
+ "kitsune_p2p 0.3.0-beta-dev.27",
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.13",
+ "kitsune_p2p_dht 0.3.0-beta-dev.14",
+ "kitsune_p2p_dht_arc 0.3.0-beta-dev.12",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kitsune_p2p_types 0.3.0-beta-dev.18",
+ "num_cpus",
+ "once_cell",
+ "opentelemetry_api",
+ "parking_lot 0.10.2",
+ "pretty_assertions",
  "r2d2",
  "r2d2_sqlite_neonphog",
  "rmp-serde 0.15.5",
@@ -3505,10 +3790,10 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.3.0-beta-dev.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c18bd4a0bd0a48b4de290dc213ff590426371c11f8755128561b6672f602302"
+version = "0.3.0-beta-dev.28"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
+ "aitia",
  "async-recursion 0.3.2",
  "byteorder",
  "cfg-if 0.1.10",
@@ -3518,17 +3803,18 @@ dependencies = [
  "either",
  "fallible-iterator",
  "futures",
- "holo_hash",
- "holochain_keystore",
- "holochain_nonce",
+ "hc_sleuth",
+ "holo_hash 0.3.0-beta-dev.16",
+ "holochain_keystore 0.3.0-beta-dev.21",
+ "holochain_nonce 0.3.0-beta-dev.22 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "holochain_p2p",
  "holochain_serialized_bytes",
- "holochain_sqlite",
- "holochain_state_types",
- "holochain_types",
- "holochain_util",
- "holochain_zome_types",
- "kitsune_p2p",
+ "holochain_sqlite 0.3.0-beta-dev.26",
+ "holochain_state_types 0.3.0-beta-dev.26",
+ "holochain_types 0.3.0-beta-dev.26",
+ "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "holochain_zome_types 0.3.0-beta-dev.20",
+ "kitsune_p2p 0.3.0-beta-dev.25",
  "mockall",
  "one_err",
  "parking_lot 0.10.2",
@@ -3544,20 +3830,47 @@ dependencies = [
 
 [[package]]
 name = "holochain_state_types"
-version = "0.3.0-beta-dev.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a876215c26f2f5314e7afa5bc9304e08c63e048d3a746c9a66ad8c7c9522aa2d"
+version = "0.3.0-beta-dev.26"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
- "holo_hash",
- "holochain_integrity_types",
+ "holo_hash 0.3.0-beta-dev.16",
+ "holochain_integrity_types 0.3.0-beta-dev.19",
+ "serde",
+]
+
+[[package]]
+name = "holochain_state_types"
+version = "0.3.0-beta-dev.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68dcb5140a96350a2f30f357e175f7d511bfc38b5e0399ee1b65ad7f9cbfec9e"
+dependencies = [
+ "holo_hash 0.3.0-beta-dev.18",
+ "holochain_integrity_types 0.3.0-beta-dev.21",
  "serde",
 ]
 
 [[package]]
 name = "holochain_trace"
-version = "0.3.0-beta-dev.2"
+version = "0.3.0-beta-dev.3"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+dependencies = [
+ "chrono",
+ "derive_more",
+ "inferno 0.11.16",
+ "once_cell",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "tracing-core",
+ "tracing-serde",
+ "tracing-subscriber 0.3.17",
+]
+
+[[package]]
+name = "holochain_trace"
+version = "0.3.0-beta-dev.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572aef66fe319c0b5ff0058e584cd3e3938dc3f7a3ec406f282c71b6d6fa4f42"
+checksum = "0c617c7970f8724ba3a492ae55c42f61c15d2c0702ace37c7e6de1897a7841eb"
 dependencies = [
  "chrono",
  "derive_more",
@@ -3573,9 +3886,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.3.0-beta-dev.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48412592cbb2c246bf0c6a70d8583966698f418f0cd9e1690cbab9b8d7574e65"
+version = "0.3.0-beta-dev.26"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3587,24 +3899,82 @@ dependencies = [
  "derive_builder",
  "derive_more",
  "either",
- "fixt",
+ "fixt 0.3.0-beta-dev.0 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "flate2",
  "futures",
  "getrandom 0.2.7",
- "holo_hash",
- "holochain_keystore",
- "holochain_nonce",
+ "holo_hash 0.3.0-beta-dev.16",
+ "holochain_keystore 0.3.0-beta-dev.21",
+ "holochain_nonce 0.3.0-beta-dev.22 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "holochain_serialized_bytes",
- "holochain_sqlite",
- "holochain_trace",
- "holochain_util",
+ "holochain_sqlite 0.3.0-beta-dev.26",
+ "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "holochain_wasmer_host",
- "holochain_zome_types",
+ "holochain_zome_types 0.3.0-beta-dev.20",
  "itertools 0.10.5",
- "kitsune_p2p_dht",
+ "kitsune_p2p_dht 0.3.0-beta-dev.12",
  "lazy_static",
  "mockall",
- "mr_bundle",
+ "mr_bundle 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "must_future",
+ "nanoid 0.3.0",
+ "one_err",
+ "parking_lot 0.10.2",
+ "rand 0.8.5",
+ "regex",
+ "rusqlite",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_json",
+ "serde_with 1.14.0",
+ "serde_yaml 0.9.25",
+ "shrinkwraprs",
+ "strum 0.18.0",
+ "strum_macros 0.18.0",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "wasmer",
+ "wasmer-middlewares",
+]
+
+[[package]]
+name = "holochain_types"
+version = "0.3.0-beta-dev.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873a2f9b96cdc9e341c060cf13149b136380f41dbc01b548c42e0bee3988ccb5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "automap",
+ "backtrace",
+ "base64 0.13.1",
+ "cfg-if 0.1.10",
+ "chrono",
+ "derive_builder",
+ "derive_more",
+ "either",
+ "fixt 0.3.0-beta-dev.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2",
+ "futures",
+ "getrandom 0.2.7",
+ "holo_hash 0.3.0-beta-dev.18",
+ "holochain_keystore 0.3.0-beta-dev.23",
+ "holochain_nonce 0.3.0-beta-dev.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_serialized_bytes",
+ "holochain_sqlite 0.3.0-beta-dev.28",
+ "holochain_trace 0.3.0-beta-dev.5",
+ "holochain_util 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_wasmer_host",
+ "holochain_zome_types 0.3.0-beta-dev.22",
+ "itertools 0.10.5",
+ "kitsune_p2p_dht 0.3.0-beta-dev.14",
+ "lazy_static",
+ "mockall",
+ "mr_bundle 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "must_future",
  "nanoid 0.3.0",
  "one_err",
@@ -3631,9 +4001,27 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.3.0-beta-dev.2"
+version = "0.3.0-beta-dev.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53418d802f48000188efcae179b0d51350a448d15add7af52da921cef7dc2ff0"
+checksum = "35a22ca5f762735382c729c6e3250be96045f93b1e5d3e79f45a91691a3298e5"
+dependencies = [
+ "backtrace",
+ "cfg-if 0.1.10",
+ "derive_more",
+ "dunce",
+ "futures",
+ "getrandom 0.2.7",
+ "num_cpus",
+ "once_cell",
+ "rpassword 7.2.0",
+ "sodoken",
+ "tokio",
+]
+
+[[package]]
+name = "holochain_util"
+version = "0.3.0-beta-dev.3"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "backtrace",
  "cfg-if 0.1.10",
@@ -3650,12 +4038,11 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_test_utils"
-version = "0.3.0-beta-dev.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63062a1206a6b89cd4a4075b7f5461e41a2e074e6d1982e085731ea3fcf38f0b"
+version = "0.3.0-beta-dev.27"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
- "holochain_types",
- "holochain_util",
+ "holochain_types 0.3.0-beta-dev.26",
+ "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "strum 0.18.0",
  "strum_macros 0.18.0",
  "toml 0.5.11",
@@ -3664,9 +4051,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_common"
-version = "0.0.86"
+version = "0.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d90da174e7db13ecce8279052d6e7394a101a0bcf63a990404419ee7d7d06d1"
+checksum = "91334617b53995b436796417abf4cfca516c33404842e60025c26321329c8734"
 dependencies = [
  "holochain_serialized_bytes",
  "serde",
@@ -3678,9 +4065,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_guest"
-version = "0.0.86"
+version = "0.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa28c28213791d36359d083d892371bdddf71148412e411ffbc748d048bfaa22"
+checksum = "30a4e3dcf97f42847f0ea8a4ed33d6ccf718764ed00f5a73390e9b4e5319b719"
 dependencies = [
  "holochain_serialized_bytes",
  "holochain_wasmer_common",
@@ -3692,15 +4079,15 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_host"
-version = "0.0.86"
+version = "0.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d8d17c6621725b32feab8499002fd9bd10e19ccd0b33e715b27ebe835c7fd8"
+checksum = "52e7c5fd84c6b3015d015ebcbc5ec90d95e97390251657dd2700096743626f59"
 dependencies = [
  "bimap",
  "bytes",
+ "hex",
  "holochain_serialized_bytes",
  "holochain_wasmer_common",
- "once_cell",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "serde",
@@ -3730,9 +4117,33 @@ dependencies = [
 
 [[package]]
 name = "holochain_websocket"
-version = "0.3.0-beta-dev.5"
+version = "0.3.0-beta-dev.6"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+dependencies = [
+ "futures",
+ "ghost_actor 0.4.0-alpha.5",
+ "holochain_serialized_bytes",
+ "must_future",
+ "nanoid 0.3.0",
+ "net2",
+ "serde",
+ "serde_bytes",
+ "stream-cancel",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite 0.13.0",
+ "tracing",
+ "tracing-futures",
+ "tungstenite 0.12.0",
+ "url2",
+]
+
+[[package]]
+name = "holochain_websocket"
+version = "0.3.0-beta-dev.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70407f22848ce2fb9d78ad178be72cd0a26d86ab49dbe58d20e9c5a356b0ef02"
+checksum = "62c3c7bd9d6b6aa092987a0d58860d9f7fbedf0522733184d22a12736a9db7f3"
 dependencies = [
  "futures",
  "ghost_actor 0.4.0-alpha.5",
@@ -3755,21 +4166,51 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.3.0-beta-dev.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f4e35fefb23b49ea2c1ebec928053ff850319c03980d925afbbe2b12ec6eb"
+version = "0.3.0-beta-dev.20"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "derive_builder",
- "holo_hash",
- "holochain_integrity_types",
- "holochain_nonce",
- "holochain_secure_primitive",
+ "holo_hash 0.3.0-beta-dev.16",
+ "holochain_integrity_types 0.3.0-beta-dev.19",
+ "holochain_nonce 0.3.0-beta-dev.22 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "holochain_secure_primitive 0.3.0-beta-dev.21 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "holochain_serialized_bytes",
  "holochain_wasmer_common",
- "kitsune_p2p_bin_data",
- "kitsune_p2p_block",
- "kitsune_p2p_dht",
- "kitsune_p2p_timestamp",
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
+ "kitsune_p2p_block 0.3.0-beta-dev.13",
+ "kitsune_p2p_dht 0.3.0-beta-dev.12",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "nanoid 0.3.0",
+ "num_enum",
+ "paste",
+ "rusqlite",
+ "serde",
+ "serde_bytes",
+ "serde_yaml 0.9.25",
+ "shrinkwraprs",
+ "subtle",
+ "subtle-encoding",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "holochain_zome_types"
+version = "0.3.0-beta-dev.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c25d0c81babaa483567a0394982d29f2c05fb36044595312d5bc33c6ffc4982"
+dependencies = [
+ "derive_builder",
+ "holo_hash 0.3.0-beta-dev.18",
+ "holochain_integrity_types 0.3.0-beta-dev.21",
+ "holochain_nonce 0.3.0-beta-dev.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_secure_primitive 0.3.0-beta-dev.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_serialized_bytes",
+ "holochain_wasmer_common",
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.13",
+ "kitsune_p2p_block 0.3.0-beta-dev.15",
+ "kitsune_p2p_dht 0.3.0-beta-dev.14",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "nanoid 0.3.0",
  "num_enum",
  "paste",
@@ -4472,30 +4913,73 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p"
-version = "0.3.0-beta-dev.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85991eff40fc84390fdf4e9e7fce2808024027a8b20f5defe2ec77e3e95053d7"
+version = "0.3.0-beta-dev.25"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "arrayref",
  "base64 0.21.3",
  "bloomfilter",
  "bytes",
  "derive_more",
- "fixt",
+ "fixt 0.3.0-beta-dev.0 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "futures",
  "ghost_actor 0.3.0-alpha.6",
  "governor",
- "holochain_trace",
+ "holochain_trace 0.3.0-beta-dev.3",
  "itertools 0.11.0",
- "kitsune_p2p_bin_data",
- "kitsune_p2p_block",
- "kitsune_p2p_bootstrap_client",
- "kitsune_p2p_fetch",
- "kitsune_p2p_mdns",
- "kitsune_p2p_proxy",
- "kitsune_p2p_timestamp",
- "kitsune_p2p_transport_quic",
- "kitsune_p2p_types",
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
+ "kitsune_p2p_block 0.3.0-beta-dev.13",
+ "kitsune_p2p_bootstrap_client 0.3.0-beta-dev.22",
+ "kitsune_p2p_fetch 0.3.0-beta-dev.18",
+ "kitsune_p2p_mdns 0.3.0-beta-dev.1 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "kitsune_p2p_proxy 0.3.0-beta-dev.16",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "kitsune_p2p_transport_quic 0.3.0-beta-dev.16",
+ "kitsune_p2p_types 0.3.0-beta-dev.16",
+ "must_future",
+ "nanoid 0.4.0",
+ "num-traits",
+ "once_cell",
+ "opentelemetry_api",
+ "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tx5",
+ "url2",
+]
+
+[[package]]
+name = "kitsune_p2p"
+version = "0.3.0-beta-dev.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c618205501e91cf77ed61c88c27a541db69c80bd082647541e3cf593bc08cf"
+dependencies = [
+ "arrayref",
+ "base64 0.21.3",
+ "bloomfilter",
+ "bytes",
+ "derive_more",
+ "fixt 0.3.0-beta-dev.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "ghost_actor 0.3.0-alpha.6",
+ "governor",
+ "holochain_trace 0.3.0-beta-dev.5",
+ "itertools 0.11.0",
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.13",
+ "kitsune_p2p_block 0.3.0-beta-dev.15",
+ "kitsune_p2p_bootstrap_client 0.3.0-beta-dev.24",
+ "kitsune_p2p_fetch 0.3.0-beta-dev.20",
+ "kitsune_p2p_mdns 0.3.0-beta-dev.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kitsune_p2p_proxy 0.3.0-beta-dev.18",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kitsune_p2p_transport_quic 0.3.0-beta-dev.18",
+ "kitsune_p2p_types 0.3.0-beta-dev.18",
  "must_future",
  "nanoid 0.4.0",
  "num-traits",
@@ -4516,14 +5000,28 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bin_data"
-version = "0.3.0-beta-dev.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d4d5b1393c67ee9bd27390d45745a6cc2f13bf1c668ce5e7531f5bfade796c"
+version = "0.3.0-beta-dev.11"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "base64 0.13.1",
  "derive_more",
- "holochain_util",
- "kitsune_p2p_dht_arc",
+ "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "kitsune_p2p_dht_arc 0.3.0-beta-dev.10",
+ "serde",
+ "serde_bytes",
+ "shrinkwraprs",
+]
+
+[[package]]
+name = "kitsune_p2p_bin_data"
+version = "0.3.0-beta-dev.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a4ebf438c25f8f8113181b35b5af396f05c45520d9c90c4838507d310d33da"
+dependencies = [
+ "base64 0.13.1",
+ "derive_more",
+ "holochain_util 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kitsune_p2p_dht_arc 0.3.0-beta-dev.12",
  "serde",
  "serde_bytes",
  "shrinkwraprs",
@@ -4531,25 +5029,54 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_block"
-version = "0.3.0-beta-dev.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "047ba98640853fe6a2c27c21b1ce2062b7d90c12d285a95e20a9445b02c5daa6"
+version = "0.3.0-beta-dev.13"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
- "kitsune_p2p_bin_data",
- "kitsune_p2p_timestamp",
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "serde",
+]
+
+[[package]]
+name = "kitsune_p2p_block"
+version = "0.3.0-beta-dev.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5542cb12df195ade9f916226b247a1e20fffe009510fc0159d6fe6f6a8a793b2"
+dependencies = [
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.13",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
 ]
 
 [[package]]
 name = "kitsune_p2p_bootstrap"
-version = "0.2.0-beta-dev.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d67cf0e6a355c504294dc079be4537eddc3d2424676f8df0e0a403e12c77859"
+version = "0.2.0-beta-dev.16"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "clap 4.4.8",
  "futures",
- "kitsune_p2p_bin_data",
- "kitsune_p2p_types",
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
+ "kitsune_p2p_types 0.3.0-beta-dev.16",
+ "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_bytes",
+ "thiserror",
+ "tokio",
+ "warp",
+]
+
+[[package]]
+name = "kitsune_p2p_bootstrap"
+version = "0.2.0-beta-dev.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c8a4c2d9e617dbb59178dfd1150c1d025b05f856d35d4cde7441a5b25fedc5"
+dependencies = [
+ "clap 4.4.8",
+ "futures",
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.13",
+ "kitsune_p2p_types 0.3.0-beta-dev.18",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "reqwest",
@@ -4562,14 +5089,31 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bootstrap_client"
-version = "0.3.0-beta-dev.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0760c1a10d53f06cd6d89dda4319a588f8973882e1effba7afc87b16c448854c"
+version = "0.3.0-beta-dev.22"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "ed25519-dalek",
- "kitsune_p2p_bin_data",
- "kitsune_p2p_bootstrap",
- "kitsune_p2p_types",
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
+ "kitsune_p2p_bootstrap 0.2.0-beta-dev.16",
+ "kitsune_p2p_types 0.3.0-beta-dev.16",
+ "once_cell",
+ "reqwest",
+ "serde",
+ "serde_bytes",
+ "tokio",
+ "url2",
+]
+
+[[package]]
+name = "kitsune_p2p_bootstrap_client"
+version = "0.3.0-beta-dev.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6efc653b5100b424f3d6e65d12babdf86fd14d6693792c870c9143efe74670"
+dependencies = [
+ "ed25519-dalek",
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.13",
+ "kitsune_p2p_bootstrap 0.2.0-beta-dev.18",
+ "kitsune_p2p_types 0.3.0-beta-dev.18",
  "once_cell",
  "reqwest",
  "serde",
@@ -4580,15 +5124,35 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht"
-version = "0.3.0-beta-dev.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8bf8793b3f41cc82e3f6b22195fa5480cfadf218d5c465c92664ac2ba873bb"
+version = "0.3.0-beta-dev.12"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "derivative",
  "derive_more",
  "futures",
- "kitsune_p2p_dht_arc",
- "kitsune_p2p_timestamp",
+ "kitsune_p2p_dht_arc 0.3.0-beta-dev.10",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "must_future",
+ "num-traits",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "statrs",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "kitsune_p2p_dht"
+version = "0.3.0-beta-dev.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808a2595c1a546fc2b67dbc20bf3cbad62f295fbcfc3760a2ac55bd5caaab1c5"
+dependencies = [
+ "derivative",
+ "derive_more",
+ "futures",
+ "kitsune_p2p_dht_arc 0.3.0-beta-dev.12",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "must_future",
  "num-traits",
  "once_cell",
@@ -4601,14 +5165,28 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht_arc"
-version = "0.3.0-beta-dev.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba6819d99c5355ac07246a7781487f37c65a8eda8734205d009204828625f58"
+version = "0.3.0-beta-dev.10"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "derive_more",
  "gcollections",
  "intervallum",
- "kitsune_p2p_timestamp",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "num-traits",
+ "rusqlite",
+ "serde",
+]
+
+[[package]]
+name = "kitsune_p2p_dht_arc"
+version = "0.3.0-beta-dev.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2254e8accf299ffbb4e13030de3fdf890f79255a3b8ebb617f14cf3b10625cd"
+dependencies = [
+ "derive_more",
+ "gcollections",
+ "intervallum",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits",
  "rusqlite",
  "serde",
@@ -4616,13 +5194,27 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_fetch"
-version = "0.3.0-beta-dev.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b633d53cd9c35ed5800c2d9bf52ee2e2e61478a5492f5f01531a4b89f615bd"
+version = "0.3.0-beta-dev.18"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "derive_more",
- "kitsune_p2p_timestamp",
- "kitsune_p2p_types",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "kitsune_p2p_types 0.3.0-beta-dev.16",
+ "linked-hash-map",
+ "serde",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "kitsune_p2p_fetch"
+version = "0.3.0-beta-dev.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6431330a67e529506695053dd9b12b14f435e40e316edc6a72ea400afaa2b9b7"
+dependencies = [
+ "derive_more",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kitsune_p2p_types 0.3.0-beta-dev.18",
  "linked-hash-map",
  "serde",
  "tokio",
@@ -4645,17 +5237,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "kitsune_p2p_mdns"
+version = "0.3.0-beta-dev.1"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+dependencies = [
+ "base64 0.21.3",
+ "err-derive 0.3.1",
+ "futures-util",
+ "libmdns",
+ "mdns",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "kitsune_p2p_proxy"
-version = "0.3.0-beta-dev.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc483ea582ea76ed3a893d82f87ed0bfd4184f803ec79701a893462889055ea6"
+version = "0.3.0-beta-dev.16"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "base64 0.21.3",
  "derive_more",
  "futures",
- "holochain_trace",
- "kitsune_p2p_transport_quic",
- "kitsune_p2p_types",
+ "holochain_trace 0.3.0-beta-dev.3",
+ "kitsune_p2p_transport_quic 0.3.0-beta-dev.16",
+ "kitsune_p2p_types 0.3.0-beta-dev.16",
+ "serde",
+ "serde_bytes",
+ "structopt",
+ "tokio",
+]
+
+[[package]]
+name = "kitsune_p2p_proxy"
+version = "0.3.0-beta-dev.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d834dd725a5b3ad21661f1415b8a0c547c221619bc188d1a776238e1bb5ce619"
+dependencies = [
+ "base64 0.21.3",
+ "derive_more",
+ "futures",
+ "holochain_trace 0.3.0-beta-dev.5",
+ "kitsune_p2p_transport_quic 0.3.0-beta-dev.18",
+ "kitsune_p2p_types 0.3.0-beta-dev.18",
  "serde",
  "serde_bytes",
  "structopt",
@@ -4674,15 +5297,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "kitsune_p2p_timestamp"
+version = "0.3.0-beta-dev.5"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+dependencies = [
+ "chrono",
+ "rusqlite",
+ "serde",
+]
+
+[[package]]
 name = "kitsune_p2p_transport_quic"
-version = "0.3.0-beta-dev.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcb9618a72ca7e93e29ba1bc5a537507c9ab0a1d689b56618b86ac1df450343"
+version = "0.3.0-beta-dev.16"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "blake2b_simd 1.0.1",
  "futures",
  "if-addrs 0.8.0",
- "kitsune_p2p_types",
+ "kitsune_p2p_types 0.3.0-beta-dev.16",
+ "quinn",
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "kitsune_p2p_transport_quic"
+version = "0.3.0-beta-dev.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d576bc7441a757773c527a043029f93fda2ab559a6d045203a4ce04c03f71c70"
+dependencies = [
+ "blake2b_simd 1.0.1",
+ "futures",
+ "if-addrs 0.8.0",
+ "kitsune_p2p_types 0.3.0-beta-dev.18",
  "quinn",
  "rustls",
  "tokio",
@@ -4691,19 +5339,50 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_types"
-version = "0.3.0-beta-dev.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14063194187b34cb3bf6006a185fa9aeaeda82e6ac7452b165b1760b4251ce65"
+version = "0.3.0-beta-dev.16"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "base64 0.21.3",
  "derive_more",
  "futures",
  "ghost_actor 0.3.0-alpha.6",
- "holochain_trace",
- "kitsune_p2p_bin_data",
- "kitsune_p2p_dht",
- "kitsune_p2p_dht_arc",
- "kitsune_p2p_timestamp",
+ "holochain_trace 0.3.0-beta-dev.3",
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
+ "kitsune_p2p_dht 0.3.0-beta-dev.12",
+ "kitsune_p2p_dht_arc 0.3.0-beta-dev.10",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "lair_keystore_api",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "paste",
+ "rmp-serde 0.15.5",
+ "rustls",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "sysinfo 0.29.10",
+ "thiserror",
+ "tokio",
+ "ureq",
+ "url 2.4.1",
+ "url2",
+]
+
+[[package]]
+name = "kitsune_p2p_types"
+version = "0.3.0-beta-dev.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "690729065c85a6b5faf7e5674918c6979933a61a1bfd1490f81afa8b8a084efd"
+dependencies = [
+ "base64 0.21.3",
+ "derive_more",
+ "futures",
+ "ghost_actor 0.3.0-alpha.6",
+ "holochain_trace 0.3.0-beta-dev.5",
+ "kitsune_p2p_bin_data 0.3.0-beta-dev.13",
+ "kitsune_p2p_dht 0.3.0-beta-dev.14",
+ "kitsune_p2p_dht_arc 0.3.0-beta-dev.12",
+ "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lair_keystore_api",
  "once_cell",
  "parking_lot 0.12.1",
@@ -4782,7 +5461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843c7dbcbc8d75eef0b30397a7eb0d04549aabeff4ea69ebd272aea991555746"
 dependencies = [
  "lair_keystore_api",
- "pretty_assertions 1.4.0",
+ "pretty_assertions",
  "rpassword 7.2.0",
  "rusqlite",
  "sqlformat 0.2.2",
@@ -4824,10 +5503,10 @@ version = "0.1.0"
 dependencies = [
  "ascii",
  "async-trait",
- "holochain_conductor_api",
+ "holochain_conductor_api 0.3.0-beta-dev.29",
  "holochain_launcher_utils",
- "holochain_types",
- "holochain_zome_types",
+ "holochain_types 0.3.0-beta-dev.26",
+ "holochain_zome_types 0.3.0-beta-dev.20",
  "lair_keystore_api",
  "log",
  "nanoid 0.4.0",
@@ -5247,15 +5926,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
-dependencies = [
- "autocfg 1.1.0",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
@@ -5269,7 +5939,7 @@ version = "0.88.1"
 source = "git+https://github.com/matthme/hc-zome-mere-memory?branch=holochain-0.3.0-beta-dev.20#4c3beb677fde4ae619a220dfd62f1aed35d43336"
 dependencies = [
  "getrandom 0.2.7",
- "hdi",
+ "hdi 0.4.0-beta-dev.22",
  "serde",
  "sha2 0.10.7",
 ]
@@ -5359,16 +6029,36 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "mr_bundle"
-version = "0.3.0-beta-dev.2"
+version = "0.3.0-beta-dev.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3290fdeb987dedc51c9f5c7aa1a33c23dc9cf3e1ab2f618b5933aef2e686467"
+checksum = "e62892846095d6a57e622802cd297e7029217025798308d192de79c88e126c48"
 dependencies = [
  "bytes",
  "derive_more",
  "either",
  "flate2",
  "futures",
- "holochain_util",
+ "holochain_util 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest",
+ "rmp-serde 0.15.5",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_yaml 0.9.25",
+ "thiserror",
+]
+
+[[package]]
+name = "mr_bundle"
+version = "0.3.0-beta-dev.3"
+source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+dependencies = [
+ "bytes",
+ "derive_more",
+ "either",
+ "flate2",
+ "futures",
+ "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
  "reqwest",
  "rmp-serde 0.15.5",
  "serde",
@@ -6011,15 +6701,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "output_vt100"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6506,18 +7187,6 @@ checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
 dependencies = [
  "predicates-core",
  "termtree",
-]
-
-[[package]]
-name = "pretty_assertions"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
-dependencies = [
- "ansi_term",
- "ctor",
- "diff",
- "output_vt100",
 ]
 
 [[package]]
@@ -9906,29 +10575,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-downcast"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dac026d43bcca6e7ce1c0956ba68f59edf6403e8e930a5d891be72c31a44340"
-dependencies = [
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "wasm-bindgen-downcast-macros",
-]
-
-[[package]]
-name = "wasm-bindgen-downcast-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5020cfa87c7cecefef118055d44e3c1fc122c7ec25701d528ee458a0b45f38f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "wasm-bindgen-futures"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10008,9 +10654,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer"
-version = "4.2.2"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e626f958755a90a6552b9528f59b58a62ae288e6c17fcf40e99495bc33c60f0"
+checksum = "ce45cc009177ca345a6d041f9062305ad467d15e7d41494f5b81ab46d62d7a58"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",
@@ -10025,7 +10671,6 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasm-bindgen",
- "wasm-bindgen-downcast",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
  "wasmer-derive",
@@ -10037,9 +10682,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "4.2.2"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848e1922694cf97f4df680a0534c9d72c836378b5eb2313c1708fe1a75b40044"
+checksum = "e044f6140c844602b920deb4526aea3cc9c0d7cf23f00730bb9b2034669f522a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -10064,9 +10709,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "4.2.2"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d96bce6fad15a954edcfc2749b59e47ea7de524b6ef3df392035636491a40b4"
+checksum = "32ce02358eb44a149d791c1d6648fb7f8b2f99cd55e3c4eef0474653ec8cc889"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -10083,9 +10728,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "4.2.2"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f08f80d166a9279671b7af7a09409c28ede2e0b4e3acabbf0e3cb22c8038ba7"
+checksum = "c782d80401edb08e1eba206733f7859db6c997fc5a7f5fb44edc3ecd801468f6"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -10095,9 +10740,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "4.2.2"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb4b87c0ea9f8636c81a8ab8f52bad01c8623c9fcbb3db5f367d5f157fada30"
+checksum = "66d4f27f76b7b5325476c8851f34920ae562ef0de3c830fdbc4feafff6782187"
 dependencies = [
  "wasmer",
  "wasmer-types",
@@ -10106,9 +10751,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "4.2.2"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2c892882f0b416783fb4310e5697f5c30587f6f9555f9d4f2be85ab39d5d3d"
+checksum = "fd09e80d4d74bb9fd0ce6c3c106b1ceba1a050f9948db9d9b78ae53c172d6157"
 dependencies = [
  "bytecheck",
  "enum-iterator",
@@ -10122,9 +10767,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "4.2.2"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0a9a57b627fb39e5a491058d4365f099bc9b140031c000fded24a3306d9480"
+checksum = "bdcd8a4fd36414a7b6a003dbfbd32393bce3e155d715dd877c05c1b7a41d224d"
 dependencies = [
  "backtrace",
  "cc",
@@ -10139,7 +10784,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "mach",
- "memoffset 0.8.0",
+ "memoffset 0.9.0",
  "more-asserts",
  "region",
  "scopeguard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,12 +95,13 @@ dependencies = [
 
 [[package]]
 name = "aitia"
-version = "0.1.0"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+version = "0.2.0-beta-dev.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fefc2c98c575c9c3abeb5d4d7359ed8a2dab00625fc73a20ccaddba3236aebdf"
 dependencies = [
  "anyhow",
  "derive_more",
- "holochain_trace 0.3.0-beta-dev.5",
+ "holochain_trace",
  "parking_lot 0.10.2",
  "petgraph",
  "regex",
@@ -1691,7 +1692,7 @@ dependencies = [
  "essence_payloads",
  "flate2",
  "hc_crud_caps",
- "hdk 0.3.0-beta-dev.26",
+ "hdk",
  "hex",
  "rmp-serde 0.15.5",
  "serde",
@@ -2133,22 +2134,6 @@ name = "fixt"
 version = "0.3.0-beta-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15eb8dc36476da0d07a264766fba94be61ad66a52f05cadb82453ef723465de9"
-dependencies = [
- "holochain_serialized_bytes",
- "lazy_static",
- "parking_lot 0.10.2",
- "paste",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "serde",
- "strum 0.18.0",
- "strum_macros 0.18.0",
-]
-
-[[package]]
-name = "fixt"
-version = "0.3.0-beta-dev.0"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -2856,8 +2841,8 @@ name = "hc_crud_caps"
 version = "0.9.1"
 source = "git+https://github.com/matthme/rust-hc-crud-caps?branch=holochain-0.3.0-beta-dev.20#24fe3f997de86c72f71f5653f3f1d6239a137386"
 dependencies = [
- "hdk 0.3.0-beta-dev.26",
- "holo_hash 0.3.0-beta-dev.18",
+ "hdk",
+ "holo_hash",
  "serde",
  "thiserror",
 ]
@@ -2878,17 +2863,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "hc_seed_bundle"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397f372672597305f39af2b2abf389a077077489bc4f412e7ed574214c268208"
+dependencies = [
+ "futures",
+ "one_err",
+ "rmp-serde 0.15.5",
+ "rmpv",
+ "serde",
+ "serde_bytes",
+ "sodoken",
+]
+
+[[package]]
 name = "hc_sleuth"
-version = "0.1.0"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+version = "0.2.0-beta-dev.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4883350cf8e5a2adc16e083b088ad1678bcc11a3216682ef775fa7a08208ced5"
 dependencies = [
  "aitia",
  "anyhow",
  "derive_more",
- "holochain_state_types 0.3.0-beta-dev.26",
- "holochain_trace 0.3.0-beta-dev.3",
- "holochain_types 0.3.0-beta-dev.26",
- "kitsune_p2p 0.3.0-beta-dev.25",
+ "holochain_state_types",
+ "holochain_trace",
+ "holochain_types",
+ "kitsune_p2p",
  "once_cell",
  "parking_lot 0.10.2",
  "petgraph",
@@ -2901,29 +2902,13 @@ dependencies = [
 
 [[package]]
 name = "hdi"
-version = "0.4.0-beta-dev.20"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "hdk_derive 0.3.0-beta-dev.19",
- "holo_hash 0.3.0-beta-dev.16",
- "holochain_integrity_types 0.3.0-beta-dev.19",
- "holochain_wasmer_guest",
- "paste",
- "serde",
- "serde_bytes",
- "tracing",
- "tracing-core",
-]
-
-[[package]]
-name = "hdi"
-version = "0.4.0-beta-dev.22"
+version = "0.4.0-beta-dev.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c50adb6a522c18234160667d348325e9ebd880048ac79a09925443d31c5f6ad"
+checksum = "dfb9de103346599892e1b5e451afb08e8e1dc78e82e66241e469d9a7fc459ebd"
 dependencies = [
- "hdk_derive 0.3.0-beta-dev.21",
- "holo_hash 0.3.0-beta-dev.18",
- "holochain_integrity_types 0.3.0-beta-dev.21",
+ "hdk_derive",
+ "holo_hash",
+ "holochain_integrity_types",
  "holochain_wasmer_guest",
  "paste",
  "serde",
@@ -2934,35 +2919,16 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.3.0-beta-dev.24"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "getrandom 0.2.7",
- "hdi 0.4.0-beta-dev.20",
- "hdk_derive 0.3.0-beta-dev.19",
- "holo_hash 0.3.0-beta-dev.16",
- "holochain_wasmer_guest",
- "holochain_zome_types 0.3.0-beta-dev.20",
- "paste",
- "serde",
- "serde_bytes",
- "thiserror",
- "tracing",
- "tracing-core",
-]
-
-[[package]]
-name = "hdk"
-version = "0.3.0-beta-dev.26"
+version = "0.3.0-beta-dev.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d602a52411cd1136d6858ed87d13bc362f2a24f39ba2ae22d2405a2f5283d64"
+checksum = "c168b350267fbab81ae0571e686c6644f578c1468f03a61d04c5d874181b084e"
 dependencies = [
  "getrandom 0.2.7",
- "hdi 0.4.0-beta-dev.22",
- "hdk_derive 0.3.0-beta-dev.21",
- "holo_hash 0.3.0-beta-dev.18",
+ "hdi",
+ "hdk_derive",
+ "holo_hash",
  "holochain_wasmer_guest",
- "holochain_zome_types 0.3.0-beta-dev.22",
+ "holochain_zome_types",
  "paste",
  "serde",
  "serde_bytes",
@@ -2973,28 +2939,13 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.3.0-beta-dev.19"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "darling 0.14.4",
- "heck 0.4.1",
- "holochain_integrity_types 0.3.0-beta-dev.19",
- "paste",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "hdk_derive"
-version = "0.3.0-beta-dev.21"
+version = "0.3.0-beta-dev.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ec48bc0fe3e785b238cd097e295ff66c714bc9cf0f91bcc552482446c5e00a"
+checksum = "c3aa32ba721a36233d1f8d7f00a8294c23ded0fc71c10fc0cf7f1262410c9bf6"
 dependencies = [
  "darling 0.14.4",
  "heck 0.4.1",
- "holochain_integrity_types 0.3.0-beta-dev.21",
+ "holochain_integrity_types",
  "paste",
  "proc-macro-error",
  "proc-macro2",
@@ -3079,41 +3030,19 @@ dependencies = [
 
 [[package]]
 name = "holo_hash"
-version = "0.3.0-beta-dev.16"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "base64 0.13.1",
- "blake2b_simd 0.5.11",
- "derive_more",
- "fixt 0.3.0-beta-dev.0 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "futures",
- "holochain_serialized_bytes",
- "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "holochain_wasmer_common",
- "kitsune_p2p_dht_arc 0.3.0-beta-dev.10",
- "must_future",
- "rand 0.8.5",
- "rusqlite",
- "serde",
- "serde_bytes",
- "thiserror",
-]
-
-[[package]]
-name = "holo_hash"
-version = "0.3.0-beta-dev.18"
+version = "0.3.0-beta-dev.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9782dc9476547677610bab509815cea2512588026ed9f0b695c0749bc04e3a"
+checksum = "8fd53837f2bcd89f84c68d052c413f221bbc0ea37f18e088128592e0757915fa"
 dependencies = [
  "base64 0.13.1",
  "blake2b_simd 0.5.11",
  "derive_more",
- "fixt 0.3.0-beta-dev.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixt",
  "futures",
  "holochain_serialized_bytes",
- "holochain_util 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_util",
  "holochain_wasmer_common",
- "kitsune_p2p_dht_arc 0.3.0-beta-dev.12",
+ "kitsune_p2p_dht_arc",
  "must_future",
  "rand 0.8.5",
  "rusqlite",
@@ -3124,8 +3053,9 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.3.0-beta-dev.29"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+version = "0.3.0-beta-dev.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d18e5df01f9f574edc32cc8b299f31f53b62bf8f8b4fe87ce6f614b27935a"
 dependencies = [
  "aitia",
  "anyhow",
@@ -3141,44 +3071,44 @@ dependencies = [
  "directories",
  "either",
  "fallible-iterator",
- "fixt 0.3.0-beta-dev.0 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "fixt",
  "futures",
  "get_if_addrs",
  "getrandom 0.2.7",
  "ghost_actor 0.3.0-alpha.6",
  "hc_sleuth",
- "hdk 0.3.0-beta-dev.24",
- "holo_hash 0.3.0-beta-dev.16",
+ "hdk",
+ "holo_hash",
  "holochain_cascade",
- "holochain_conductor_api 0.3.0-beta-dev.29",
- "holochain_keystore 0.3.0-beta-dev.21",
+ "holochain_conductor_api",
+ "holochain_conductor_services",
+ "holochain_keystore",
  "holochain_metrics",
- "holochain_nonce 0.3.0-beta-dev.22 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "holochain_nonce",
  "holochain_p2p",
- "holochain_secure_primitive 0.3.0-beta-dev.21 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "holochain_secure_primitive",
  "holochain_serialized_bytes",
- "holochain_services",
- "holochain_sqlite 0.3.0-beta-dev.26",
+ "holochain_sqlite",
  "holochain_state",
- "holochain_trace 0.3.0-beta-dev.3",
- "holochain_types 0.3.0-beta-dev.26",
- "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "holochain_trace",
+ "holochain_types",
+ "holochain_util",
  "holochain_wasm_test_utils",
  "holochain_wasmer_host",
- "holochain_websocket 0.3.0-beta-dev.6",
- "holochain_zome_types 0.3.0-beta-dev.20",
+ "holochain_websocket",
+ "holochain_zome_types",
  "hostname",
  "human-panic",
  "itertools 0.10.5",
- "kitsune_p2p 0.3.0-beta-dev.25",
- "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
- "kitsune_p2p_block 0.3.0-beta-dev.13",
- "kitsune_p2p_bootstrap 0.2.0-beta-dev.16",
- "kitsune_p2p_bootstrap_client 0.3.0-beta-dev.22",
- "kitsune_p2p_types 0.3.0-beta-dev.16",
+ "kitsune_p2p",
+ "kitsune_p2p_bin_data",
+ "kitsune_p2p_block",
+ "kitsune_p2p_bootstrap",
+ "kitsune_p2p_bootstrap_client",
+ "kitsune_p2p_types",
  "lazy_static",
  "mockall",
- "mr_bundle 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "mr_bundle",
  "must_future",
  "nanoid 0.3.0",
  "num_cpus",
@@ -3233,21 +3163,21 @@ dependencies = [
  "devhub_types",
  "dirs-next",
  "futures",
- "hdk 0.3.0-beta-dev.24",
+ "hdk",
  "holochain",
  "holochain_client",
  "holochain_launcher_utils",
  "holochain_manager",
- "holochain_nonce 0.3.0-beta-dev.22 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "holochain_nonce",
  "holochain_state",
- "holochain_types 0.3.0-beta-dev.26",
+ "holochain_types",
  "holochain_web_app_manager",
  "lair_keystore_manager",
  "log",
  "log4rs",
  "mere_memory_types",
  "mime_guess",
- "mr_bundle 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "mr_bundle",
  "open 5.0.0",
  "opener",
  "portpicker",
@@ -3265,29 +3195,30 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.3.0-beta-dev.29"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+version = "0.3.0-beta-dev.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfcdf0efb6fc0a661b175104c1dd7ff628b5d6995afce7465fc0004334a91c4"
 dependencies = [
  "async-trait",
  "derive_more",
  "either",
  "fallible-iterator",
- "fixt 0.3.0-beta-dev.0 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "fixt",
  "futures",
  "ghost_actor 0.3.0-alpha.6",
- "hdk 0.3.0-beta-dev.24",
- "hdk_derive 0.3.0-beta-dev.19",
- "holo_hash 0.3.0-beta-dev.16",
- "holochain_nonce 0.3.0-beta-dev.22 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "hdk",
+ "hdk_derive",
+ "holo_hash",
+ "holochain_nonce",
  "holochain_p2p",
  "holochain_serialized_bytes",
- "holochain_sqlite 0.3.0-beta-dev.26",
+ "holochain_sqlite",
  "holochain_state",
- "holochain_trace 0.3.0-beta-dev.3",
- "holochain_types 0.3.0-beta-dev.26",
- "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "holochain_zome_types 0.3.0-beta-dev.20",
- "kitsune_p2p 0.3.0-beta-dev.25",
+ "holochain_trace",
+ "holochain_types",
+ "holochain_util",
+ "holochain_zome_types",
+ "kitsune_p2p",
  "once_cell",
  "opentelemetry_api",
  "serde",
@@ -3308,13 +3239,13 @@ dependencies = [
  "holochain",
  "holochain_cli_sandbox",
  "holochain_client",
- "holochain_conductor_api 0.3.0-beta-dev.29",
+ "holochain_conductor_api",
  "holochain_launcher_utils",
- "holochain_trace 0.3.0-beta-dev.3",
- "holochain_types 0.3.0-beta-dev.26",
- "holochain_util 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_zome_types 0.3.0-beta-dev.20",
- "lair_keystore_api",
+ "holochain_trace",
+ "holochain_types",
+ "holochain_util",
+ "holochain_zome_types",
+ "lair_keystore_api 0.3.0",
  "log",
  "mime_guess",
  "notify",
@@ -3335,21 +3266,22 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_sandbox"
-version = "0.3.0-beta-dev.29"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+version = "0.3.0-beta-dev.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de7642b2505184fc902be19b85691c7c6345ce484e0f5fb56f4f8f9ebaf8ed8"
 dependencies = [
  "ansi_term",
  "anyhow",
  "chrono",
  "clap 4.4.8",
  "futures",
- "holochain_conductor_api 0.3.0-beta-dev.29",
+ "holochain_conductor_api",
  "holochain_p2p",
- "holochain_trace 0.3.0-beta-dev.3",
- "holochain_types 0.3.0-beta-dev.26",
- "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "holochain_websocket 0.3.0-beta-dev.6",
- "kitsune_p2p_types 0.3.0-beta-dev.16",
+ "holochain_trace",
+ "holochain_types",
+ "holochain_util",
+ "holochain_websocket",
+ "kitsune_p2p_types",
  "nanoid 0.3.0",
  "once_cell",
  "serde",
@@ -3372,31 +3304,32 @@ dependencies = [
  "anyhow",
  "ed25519-dalek",
  "getrandom 0.2.7",
- "holo_hash 0.3.0-beta-dev.18",
- "holochain_conductor_api 0.3.0-beta-dev.31",
+ "holo_hash",
+ "holochain_conductor_api",
  "holochain_serialized_bytes",
- "holochain_types 0.3.0-beta-dev.28",
- "holochain_websocket 0.3.0-beta-dev.8",
- "holochain_zome_types 0.3.0-beta-dev.22",
+ "holochain_types",
+ "holochain_websocket",
+ "holochain_zome_types",
  "serde",
  "url 2.4.1",
 ]
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.3.0-beta-dev.29"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+version = "0.3.0-beta-dev.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe04944d03cf9276ac44edf6f4418b28c670159a371dc0645dc79c0a3622f297"
 dependencies = [
  "derive_more",
  "directories",
- "holo_hash 0.3.0-beta-dev.16",
- "holochain_keystore 0.3.0-beta-dev.21",
+ "holo_hash",
+ "holochain_keystore",
  "holochain_serialized_bytes",
- "holochain_state_types 0.3.0-beta-dev.26",
- "holochain_types 0.3.0-beta-dev.26",
- "holochain_zome_types 0.3.0-beta-dev.20",
- "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
- "kitsune_p2p_types 0.3.0-beta-dev.16",
+ "holochain_state_types",
+ "holochain_types",
+ "holochain_zome_types",
+ "kitsune_p2p_bin_data",
+ "kitsune_p2p_types",
  "serde",
  "serde_derive",
  "serde_yaml 0.9.25",
@@ -3408,113 +3341,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "holochain_conductor_api"
-version = "0.3.0-beta-dev.31"
+name = "holochain_conductor_services"
+version = "0.2.0-beta-dev.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b853065ade656c6c94ab2175d42f0759e2d06adb2604b9b11ac2ca392cff928b"
+checksum = "accd9296de01d9600a78dc2dd5b6425d1108255089d0f61db23ab67d60027942"
 dependencies = [
- "derive_more",
- "directories",
- "holo_hash 0.3.0-beta-dev.18",
- "holochain_keystore 0.3.0-beta-dev.23",
- "holochain_serialized_bytes",
- "holochain_state_types 0.3.0-beta-dev.28",
- "holochain_types 0.3.0-beta-dev.28",
- "holochain_zome_types 0.3.0-beta-dev.22",
- "kitsune_p2p_bin_data 0.3.0-beta-dev.13",
- "kitsune_p2p_types 0.3.0-beta-dev.18",
- "serde",
- "serde_derive",
- "serde_yaml 0.9.25",
- "shrinkwraprs",
- "structopt",
- "thiserror",
- "tracing",
- "url2",
-]
-
-[[package]]
-name = "holochain_integrity_types"
-version = "0.3.0-beta-dev.19"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "derive_builder",
- "holo_hash 0.3.0-beta-dev.16",
- "holochain_secure_primitive 0.3.0-beta-dev.21 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "holochain_serialized_bytes",
- "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "paste",
- "serde",
- "serde_bytes",
- "subtle",
- "subtle-encoding",
- "tracing",
-]
-
-[[package]]
-name = "holochain_integrity_types"
-version = "0.3.0-beta-dev.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19774dd65cf49fd1cb780b0581f5592ca32ca907cc56562abfc9c5ca1492ef7"
-dependencies = [
- "derive_builder",
- "holo_hash 0.3.0-beta-dev.18",
- "holochain_secure_primitive 0.3.0-beta-dev.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_serialized_bytes",
- "holochain_util 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "paste",
- "serde",
- "serde_bytes",
- "subtle",
- "subtle-encoding",
- "tracing",
-]
-
-[[package]]
-name = "holochain_keystore"
-version = "0.3.0-beta-dev.21"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "base64 0.13.1",
+ "anyhow",
+ "async-trait",
  "derive_more",
  "futures",
- "holo_hash 0.3.0-beta-dev.16",
- "holochain_secure_primitive 0.3.0-beta-dev.21 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "holochain_serialized_bytes",
- "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "holochain_zome_types 0.3.0-beta-dev.20",
- "kitsune_p2p_types 0.3.0-beta-dev.16",
- "lair_keystore",
+ "holochain_keystore",
+ "holochain_types",
+ "mockall",
  "must_future",
- "nanoid 0.4.0",
- "one_err",
- "parking_lot 0.11.2",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "holochain_integrity_types"
+version = "0.3.0-beta-dev.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b02dd420083ff5fe785e66ef81aad61d99a93494c211881da58ce7a718305f7d"
+dependencies = [
+ "derive_builder",
+ "holo_hash",
+ "holochain_secure_primitive",
+ "holochain_serialized_bytes",
+ "holochain_util",
+ "kitsune_p2p_timestamp",
+ "paste",
  "serde",
  "serde_bytes",
- "shrinkwraprs",
- "sodoken",
- "thiserror",
- "tokio",
+ "subtle",
+ "subtle-encoding",
  "tracing",
 ]
 
 [[package]]
 name = "holochain_keystore"
-version = "0.3.0-beta-dev.23"
+version = "0.3.0-beta-dev.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36cea01831221bf2630daf924870237cfc4a3dae96f13aea2cc01bece7e76ca"
+checksum = "46f2d1738575b40936d03dfe35d28579a01469ef242fb57dec7dc292eaf67845"
 dependencies = [
  "base64 0.13.1",
  "derive_more",
  "futures",
- "holo_hash 0.3.0-beta-dev.18",
- "holochain_secure_primitive 0.3.0-beta-dev.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holo_hash",
+ "holochain_secure_primitive",
  "holochain_serialized_bytes",
- "holochain_util 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_zome_types 0.3.0-beta-dev.22",
- "kitsune_p2p_types 0.3.0-beta-dev.18",
+ "holochain_util",
+ "holochain_zome_types",
+ "kitsune_p2p_types",
  "lair_keystore",
  "must_future",
  "nanoid 0.4.0",
@@ -3534,10 +3412,10 @@ name = "holochain_launcher_utils"
 version = "0.0.5"
 dependencies = [
  "holochain_client",
- "holochain_conductor_api 0.3.0-beta-dev.29",
- "holochain_types 0.3.0-beta-dev.26",
- "holochain_zome_types 0.3.0-beta-dev.20",
- "lair_keystore_api",
+ "holochain_conductor_api",
+ "holochain_types",
+ "holochain_zome_types",
+ "lair_keystore_api 0.3.0",
  "log",
  "mime_guess",
  "open 5.0.0",
@@ -3554,12 +3432,12 @@ dependencies = [
  "enum_dispatch",
  "holochain",
  "holochain_client",
- "holochain_conductor_api 0.3.0-beta-dev.29",
+ "holochain_conductor_api",
  "holochain_p2p",
- "holochain_types 0.3.0-beta-dev.26",
+ "holochain_types",
  "lair_keystore_manager",
  "log",
- "mr_bundle 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "mr_bundle",
  "portpicker",
  "serde",
  "serde-enum-str",
@@ -3574,7 +3452,8 @@ dependencies = [
 [[package]]
 name = "holochain_metrics"
 version = "0.3.0-beta-dev.7"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1be17104fab1e58a94c3679b890ba1221c68d15ce1626a8c4e6da026b363a6"
 dependencies = [
  "influxive",
  "opentelemetry_api",
@@ -3590,42 +3469,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aca92634944f023be0808df98bfc8f484b6f23f0f1452197043f287e06511e6c"
 dependencies = [
  "getrandom 0.2.7",
- "holochain_secure_primitive 0.3.0-beta-dev.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "holochain_nonce"
-version = "0.3.0-beta-dev.22"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "getrandom 0.2.7",
- "holochain_secure_primitive 0.3.0-beta-dev.21 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "holochain_secure_primitive",
+ "kitsune_p2p_timestamp",
 ]
 
 [[package]]
 name = "holochain_p2p"
-version = "0.3.0-beta-dev.28"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+version = "0.3.0-beta-dev.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "930fc5bad82c442ba6efbfc9f80dd76f164933a6d2a3024217e758996bc8d279"
 dependencies = [
  "aitia",
  "async-trait",
  "derive_more",
- "fixt 0.3.0-beta-dev.0 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "fixt",
  "futures",
  "ghost_actor 0.3.0-alpha.6",
  "hc_sleuth",
- "holo_hash 0.3.0-beta-dev.16",
- "holochain_keystore 0.3.0-beta-dev.21",
- "holochain_nonce 0.3.0-beta-dev.22 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "holo_hash",
+ "holochain_keystore",
+ "holochain_nonce",
  "holochain_serialized_bytes",
- "holochain_trace 0.3.0-beta-dev.3",
- "holochain_types 0.3.0-beta-dev.26",
- "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "holochain_zome_types 0.3.0-beta-dev.20",
- "kitsune_p2p 0.3.0-beta-dev.25",
- "kitsune_p2p_types 0.3.0-beta-dev.16",
+ "holochain_trace",
+ "holochain_types",
+ "holochain_util",
+ "holochain_zome_types",
+ "kitsune_p2p",
+ "kitsune_p2p_types",
  "mockall",
  "rand 0.8.5",
  "serde",
@@ -3641,16 +3511,6 @@ name = "holochain_secure_primitive"
 version = "0.3.0-beta-dev.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ae856ba625c5609e536456461463d13607eda623f7cc4e4b3a54dbb43ac052"
-dependencies = [
- "paste",
- "serde",
- "subtle",
-]
-
-[[package]]
-name = "holochain_secure_primitive"
-version = "0.3.0-beta-dev.21"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
 dependencies = [
  "paste",
  "serde",
@@ -3683,71 +3543,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "holochain_services"
-version = "0.2.0-beta-dev.0"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "anyhow",
- "async-trait",
- "derive_more",
- "futures",
- "holochain_keystore 0.3.0-beta-dev.21",
- "holochain_types 0.3.0-beta-dev.26",
- "mockall",
- "must_future",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "holochain_sqlite"
-version = "0.3.0-beta-dev.26"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "anyhow",
- "async-trait",
- "chashmap",
- "derive_more",
- "fallible-iterator",
- "futures",
- "getrandom 0.2.7",
- "holo_hash 0.3.0-beta-dev.16",
- "holochain_nonce 0.3.0-beta-dev.22 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "holochain_serialized_bytes",
- "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "holochain_zome_types 0.3.0-beta-dev.20",
- "kitsune_p2p 0.3.0-beta-dev.25",
- "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
- "kitsune_p2p_dht 0.3.0-beta-dev.12",
- "kitsune_p2p_dht_arc 0.3.0-beta-dev.10",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "kitsune_p2p_types 0.3.0-beta-dev.16",
- "num_cpus",
- "once_cell",
- "opentelemetry_api",
- "parking_lot 0.10.2",
- "pretty_assertions",
- "r2d2",
- "r2d2_sqlite_neonphog",
- "rmp-serde 0.15.5",
- "rusqlite",
- "scheduled-thread-pool",
- "serde",
- "serde_derive",
- "serde_json",
- "shrinkwraprs",
- "sqlformat 0.1.8",
- "tempfile",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "holochain_sqlite"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0-beta-dev.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8c55f32f311090b7d447f3e22973708aa3b092e58a86250e26a399e16ed6582"
+checksum = "676c07bea6392cbbd26b4b6614e889f14d8d30ed7ded2706c75e68e01a005517"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3756,17 +3555,17 @@ dependencies = [
  "fallible-iterator",
  "futures",
  "getrandom 0.2.7",
- "holo_hash 0.3.0-beta-dev.18",
- "holochain_nonce 0.3.0-beta-dev.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holo_hash",
+ "holochain_nonce",
  "holochain_serialized_bytes",
- "holochain_util 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_zome_types 0.3.0-beta-dev.22",
- "kitsune_p2p 0.3.0-beta-dev.27",
- "kitsune_p2p_bin_data 0.3.0-beta-dev.13",
- "kitsune_p2p_dht 0.3.0-beta-dev.14",
- "kitsune_p2p_dht_arc 0.3.0-beta-dev.12",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "kitsune_p2p_types 0.3.0-beta-dev.18",
+ "holochain_util",
+ "holochain_zome_types",
+ "kitsune_p2p",
+ "kitsune_p2p_bin_data",
+ "kitsune_p2p_dht",
+ "kitsune_p2p_dht_arc",
+ "kitsune_p2p_timestamp",
+ "kitsune_p2p_types",
  "num_cpus",
  "once_cell",
  "opentelemetry_api",
@@ -3790,8 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.3.0-beta-dev.28"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+version = "0.3.0-beta-dev.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c0ea98391de9c18a048d8497f45305d07ce3362c41ee7789911eab0371612c1"
 dependencies = [
  "aitia",
  "async-recursion 0.3.2",
@@ -3804,17 +3604,17 @@ dependencies = [
  "fallible-iterator",
  "futures",
  "hc_sleuth",
- "holo_hash 0.3.0-beta-dev.16",
- "holochain_keystore 0.3.0-beta-dev.21",
- "holochain_nonce 0.3.0-beta-dev.22 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "holo_hash",
+ "holochain_keystore",
+ "holochain_nonce",
  "holochain_p2p",
  "holochain_serialized_bytes",
- "holochain_sqlite 0.3.0-beta-dev.26",
- "holochain_state_types 0.3.0-beta-dev.26",
- "holochain_types 0.3.0-beta-dev.26",
- "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "holochain_zome_types 0.3.0-beta-dev.20",
- "kitsune_p2p 0.3.0-beta-dev.25",
+ "holochain_sqlite",
+ "holochain_state_types",
+ "holochain_types",
+ "holochain_util",
+ "holochain_zome_types",
+ "kitsune_p2p",
  "mockall",
  "one_err",
  "parking_lot 0.10.2",
@@ -3830,47 +3630,20 @@ dependencies = [
 
 [[package]]
 name = "holochain_state_types"
-version = "0.3.0-beta-dev.26"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "holo_hash 0.3.0-beta-dev.16",
- "holochain_integrity_types 0.3.0-beta-dev.19",
- "serde",
-]
-
-[[package]]
-name = "holochain_state_types"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0-beta-dev.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68dcb5140a96350a2f30f357e175f7d511bfc38b5e0399ee1b65ad7f9cbfec9e"
+checksum = "6a27cf7329bb2fd1c9f65de3f6dbbcec9d83ffe83f3c35022fbcc175fdd0f7cc"
 dependencies = [
- "holo_hash 0.3.0-beta-dev.18",
- "holochain_integrity_types 0.3.0-beta-dev.21",
+ "holo_hash",
+ "holochain_integrity_types",
  "serde",
 ]
 
 [[package]]
 name = "holochain_trace"
-version = "0.3.0-beta-dev.3"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "chrono",
- "derive_more",
- "inferno 0.11.16",
- "once_cell",
- "serde_json",
- "thiserror",
- "tracing",
- "tracing-core",
- "tracing-serde",
- "tracing-subscriber 0.3.17",
-]
-
-[[package]]
-name = "holochain_trace"
-version = "0.3.0-beta-dev.5"
+version = "0.3.0-beta-dev.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c617c7970f8724ba3a492ae55c42f61c15d2c0702ace37c7e6de1897a7841eb"
+checksum = "70f32929393eb74339c5ab1a4cfcde33d4b77ebaa1feceb02c851640170e6aaa"
 dependencies = [
  "chrono",
  "derive_more",
@@ -3886,66 +3659,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.3.0-beta-dev.26"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "anyhow",
- "async-trait",
- "automap",
- "backtrace",
- "base64 0.13.1",
- "cfg-if 0.1.10",
- "chrono",
- "derive_builder",
- "derive_more",
- "either",
- "fixt 0.3.0-beta-dev.0 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "flate2",
- "futures",
- "getrandom 0.2.7",
- "holo_hash 0.3.0-beta-dev.16",
- "holochain_keystore 0.3.0-beta-dev.21",
- "holochain_nonce 0.3.0-beta-dev.22 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "holochain_serialized_bytes",
- "holochain_sqlite 0.3.0-beta-dev.26",
- "holochain_trace 0.3.0-beta-dev.3",
- "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "holochain_wasmer_host",
- "holochain_zome_types 0.3.0-beta-dev.20",
- "itertools 0.10.5",
- "kitsune_p2p_dht 0.3.0-beta-dev.12",
- "lazy_static",
- "mockall",
- "mr_bundle 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "must_future",
- "nanoid 0.3.0",
- "one_err",
- "parking_lot 0.10.2",
- "rand 0.8.5",
- "regex",
- "rusqlite",
- "serde",
- "serde_bytes",
- "serde_derive",
- "serde_json",
- "serde_with 1.14.0",
- "serde_yaml 0.9.25",
- "shrinkwraprs",
- "strum 0.18.0",
- "strum_macros 0.18.0",
- "tempfile",
- "thiserror",
- "tokio",
- "tracing",
- "wasmer",
- "wasmer-middlewares",
-]
-
-[[package]]
-name = "holochain_types"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0-beta-dev.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873a2f9b96cdc9e341c060cf13149b136380f41dbc01b548c42e0bee3988ccb5"
+checksum = "8cfe8c486c91e9074a79e0ef00acf0bc84ca35701c90d17bed441c27ef4c506c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3957,24 +3673,24 @@ dependencies = [
  "derive_builder",
  "derive_more",
  "either",
- "fixt 0.3.0-beta-dev.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixt",
  "flate2",
  "futures",
  "getrandom 0.2.7",
- "holo_hash 0.3.0-beta-dev.18",
- "holochain_keystore 0.3.0-beta-dev.23",
- "holochain_nonce 0.3.0-beta-dev.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holo_hash",
+ "holochain_keystore",
+ "holochain_nonce",
  "holochain_serialized_bytes",
- "holochain_sqlite 0.3.0-beta-dev.28",
- "holochain_trace 0.3.0-beta-dev.5",
- "holochain_util 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_sqlite",
+ "holochain_trace",
+ "holochain_util",
  "holochain_wasmer_host",
- "holochain_zome_types 0.3.0-beta-dev.22",
+ "holochain_zome_types",
  "itertools 0.10.5",
- "kitsune_p2p_dht 0.3.0-beta-dev.14",
+ "kitsune_p2p_dht",
  "lazy_static",
  "mockall",
- "mr_bundle 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mr_bundle",
  "must_future",
  "nanoid 0.3.0",
  "one_err",
@@ -4019,30 +3735,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "holochain_util"
-version = "0.3.0-beta-dev.3"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "backtrace",
- "cfg-if 0.1.10",
- "derive_more",
- "dunce",
- "futures",
- "getrandom 0.2.7",
- "num_cpus",
- "once_cell",
- "rpassword 7.2.0",
- "sodoken",
- "tokio",
-]
-
-[[package]]
 name = "holochain_wasm_test_utils"
-version = "0.3.0-beta-dev.27"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
+version = "0.3.0-beta-dev.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3990f2e2602bff51e08e020188c8190d5474f959aa576fb460fbf18afe1fcded"
 dependencies = [
- "holochain_types 0.3.0-beta-dev.26",
- "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "holochain_types",
+ "holochain_util",
  "strum 0.18.0",
  "strum_macros 0.18.0",
  "toml 0.5.11",
@@ -4117,33 +3816,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_websocket"
-version = "0.3.0-beta-dev.6"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "futures",
- "ghost_actor 0.4.0-alpha.5",
- "holochain_serialized_bytes",
- "must_future",
- "nanoid 0.3.0",
- "net2",
- "serde",
- "serde_bytes",
- "stream-cancel",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tokio-tungstenite 0.13.0",
- "tracing",
- "tracing-futures",
- "tungstenite 0.12.0",
- "url2",
-]
-
-[[package]]
-name = "holochain_websocket"
-version = "0.3.0-beta-dev.8"
+version = "0.3.0-beta-dev.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c3c7bd9d6b6aa092987a0d58860d9f7fbedf0522733184d22a12736a9db7f3"
+checksum = "3b7c7149900cfb951a0661a60565d1a69100c348c834f9b32e3cb99123e806d5"
 dependencies = [
  "futures",
  "ghost_actor 0.4.0-alpha.5",
@@ -4166,51 +3841,21 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.3.0-beta-dev.20"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "derive_builder",
- "holo_hash 0.3.0-beta-dev.16",
- "holochain_integrity_types 0.3.0-beta-dev.19",
- "holochain_nonce 0.3.0-beta-dev.22 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "holochain_secure_primitive 0.3.0-beta-dev.21 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "holochain_serialized_bytes",
- "holochain_wasmer_common",
- "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
- "kitsune_p2p_block 0.3.0-beta-dev.13",
- "kitsune_p2p_dht 0.3.0-beta-dev.12",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "nanoid 0.3.0",
- "num_enum",
- "paste",
- "rusqlite",
- "serde",
- "serde_bytes",
- "serde_yaml 0.9.25",
- "shrinkwraprs",
- "subtle",
- "subtle-encoding",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "holochain_zome_types"
-version = "0.3.0-beta-dev.22"
+version = "0.3.0-beta-dev.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c25d0c81babaa483567a0394982d29f2c05fb36044595312d5bc33c6ffc4982"
+checksum = "e33155846e8a1bbf2125f52bea5297d5f8e28d25c43945460ba6dc3ee3d1df0d"
 dependencies = [
  "derive_builder",
- "holo_hash 0.3.0-beta-dev.18",
- "holochain_integrity_types 0.3.0-beta-dev.21",
- "holochain_nonce 0.3.0-beta-dev.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_secure_primitive 0.3.0-beta-dev.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holo_hash",
+ "holochain_integrity_types",
+ "holochain_nonce",
+ "holochain_secure_primitive",
  "holochain_serialized_bytes",
  "holochain_wasmer_common",
- "kitsune_p2p_bin_data 0.3.0-beta-dev.13",
- "kitsune_p2p_block 0.3.0-beta-dev.15",
- "kitsune_p2p_dht 0.3.0-beta-dev.14",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kitsune_p2p_bin_data",
+ "kitsune_p2p_block",
+ "kitsune_p2p_dht",
+ "kitsune_p2p_timestamp",
  "nanoid 0.3.0",
  "num_enum",
  "paste",
@@ -4913,73 +4558,30 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p"
-version = "0.3.0-beta-dev.25"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "arrayref",
- "base64 0.21.3",
- "bloomfilter",
- "bytes",
- "derive_more",
- "fixt 0.3.0-beta-dev.0 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "futures",
- "ghost_actor 0.3.0-alpha.6",
- "governor",
- "holochain_trace 0.3.0-beta-dev.3",
- "itertools 0.11.0",
- "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
- "kitsune_p2p_block 0.3.0-beta-dev.13",
- "kitsune_p2p_bootstrap_client 0.3.0-beta-dev.22",
- "kitsune_p2p_fetch 0.3.0-beta-dev.18",
- "kitsune_p2p_mdns 0.3.0-beta-dev.1 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "kitsune_p2p_proxy 0.3.0-beta-dev.16",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "kitsune_p2p_transport_quic 0.3.0-beta-dev.16",
- "kitsune_p2p_types 0.3.0-beta-dev.16",
- "must_future",
- "nanoid 0.4.0",
- "num-traits",
- "once_cell",
- "opentelemetry_api",
- "parking_lot 0.12.1",
- "rand 0.8.5",
- "serde",
- "serde_bytes",
- "serde_json",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
- "tx5",
- "url2",
-]
-
-[[package]]
-name = "kitsune_p2p"
-version = "0.3.0-beta-dev.27"
+version = "0.3.0-beta-dev.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c618205501e91cf77ed61c88c27a541db69c80bd082647541e3cf593bc08cf"
+checksum = "6bed1f97bd853ddfeae6656382a569ae1b15b076560ffb816ac0df092a1fc6a6"
 dependencies = [
  "arrayref",
  "base64 0.21.3",
  "bloomfilter",
  "bytes",
  "derive_more",
- "fixt 0.3.0-beta-dev.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixt",
  "futures",
  "ghost_actor 0.3.0-alpha.6",
  "governor",
- "holochain_trace 0.3.0-beta-dev.5",
+ "holochain_trace",
  "itertools 0.11.0",
- "kitsune_p2p_bin_data 0.3.0-beta-dev.13",
- "kitsune_p2p_block 0.3.0-beta-dev.15",
- "kitsune_p2p_bootstrap_client 0.3.0-beta-dev.24",
- "kitsune_p2p_fetch 0.3.0-beta-dev.20",
- "kitsune_p2p_mdns 0.3.0-beta-dev.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kitsune_p2p_proxy 0.3.0-beta-dev.18",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "kitsune_p2p_transport_quic 0.3.0-beta-dev.18",
- "kitsune_p2p_types 0.3.0-beta-dev.18",
+ "kitsune_p2p_bin_data",
+ "kitsune_p2p_block",
+ "kitsune_p2p_bootstrap_client",
+ "kitsune_p2p_fetch",
+ "kitsune_p2p_mdns",
+ "kitsune_p2p_proxy",
+ "kitsune_p2p_timestamp",
+ "kitsune_p2p_transport_quic",
+ "kitsune_p2p_types",
  "must_future",
  "nanoid 0.4.0",
  "num-traits",
@@ -5000,159 +4602,79 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bin_data"
-version = "0.3.0-beta-dev.11"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "base64 0.13.1",
- "derive_more",
- "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "kitsune_p2p_dht_arc 0.3.0-beta-dev.10",
- "serde",
- "serde_bytes",
- "shrinkwraprs",
-]
-
-[[package]]
-name = "kitsune_p2p_bin_data"
-version = "0.3.0-beta-dev.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a4ebf438c25f8f8113181b35b5af396f05c45520d9c90c4838507d310d33da"
-dependencies = [
- "base64 0.13.1",
- "derive_more",
- "holochain_util 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "kitsune_p2p_dht_arc 0.3.0-beta-dev.12",
- "serde",
- "serde_bytes",
- "shrinkwraprs",
-]
-
-[[package]]
-name = "kitsune_p2p_block"
-version = "0.3.0-beta-dev.13"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "serde",
-]
-
-[[package]]
-name = "kitsune_p2p_block"
-version = "0.3.0-beta-dev.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5542cb12df195ade9f916226b247a1e20fffe009510fc0159d6fe6f6a8a793b2"
-dependencies = [
- "kitsune_p2p_bin_data 0.3.0-beta-dev.13",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
-]
-
-[[package]]
-name = "kitsune_p2p_bootstrap"
-version = "0.2.0-beta-dev.16"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "clap 4.4.8",
- "futures",
- "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
- "kitsune_p2p_types 0.3.0-beta-dev.16",
- "parking_lot 0.12.1",
- "rand 0.8.5",
- "reqwest",
- "serde",
- "serde_bytes",
- "thiserror",
- "tokio",
- "warp",
-]
-
-[[package]]
-name = "kitsune_p2p_bootstrap"
-version = "0.2.0-beta-dev.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c8a4c2d9e617dbb59178dfd1150c1d025b05f856d35d4cde7441a5b25fedc5"
-dependencies = [
- "clap 4.4.8",
- "futures",
- "kitsune_p2p_bin_data 0.3.0-beta-dev.13",
- "kitsune_p2p_types 0.3.0-beta-dev.18",
- "parking_lot 0.12.1",
- "rand 0.8.5",
- "reqwest",
- "serde",
- "serde_bytes",
- "thiserror",
- "tokio",
- "warp",
-]
-
-[[package]]
-name = "kitsune_p2p_bootstrap_client"
-version = "0.3.0-beta-dev.22"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "ed25519-dalek",
- "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
- "kitsune_p2p_bootstrap 0.2.0-beta-dev.16",
- "kitsune_p2p_types 0.3.0-beta-dev.16",
- "once_cell",
- "reqwest",
- "serde",
- "serde_bytes",
- "tokio",
- "url2",
-]
-
-[[package]]
-name = "kitsune_p2p_bootstrap_client"
-version = "0.3.0-beta-dev.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6efc653b5100b424f3d6e65d12babdf86fd14d6693792c870c9143efe74670"
-dependencies = [
- "ed25519-dalek",
- "kitsune_p2p_bin_data 0.3.0-beta-dev.13",
- "kitsune_p2p_bootstrap 0.2.0-beta-dev.18",
- "kitsune_p2p_types 0.3.0-beta-dev.18",
- "once_cell",
- "reqwest",
- "serde",
- "serde_bytes",
- "tokio",
- "url2",
-]
-
-[[package]]
-name = "kitsune_p2p_dht"
-version = "0.3.0-beta-dev.12"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "derivative",
- "derive_more",
- "futures",
- "kitsune_p2p_dht_arc 0.3.0-beta-dev.10",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "must_future",
- "num-traits",
- "once_cell",
- "rand 0.8.5",
- "serde",
- "statrs",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "kitsune_p2p_dht"
 version = "0.3.0-beta-dev.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808a2595c1a546fc2b67dbc20bf3cbad62f295fbcfc3760a2ac55bd5caaab1c5"
+checksum = "7783a27d7c512f5cdb80926bd0987929c1624043db6d03d1e74a688c2701bc1c"
+dependencies = [
+ "base64 0.13.1",
+ "derive_more",
+ "holochain_util",
+ "kitsune_p2p_dht_arc",
+ "serde",
+ "serde_bytes",
+ "shrinkwraprs",
+]
+
+[[package]]
+name = "kitsune_p2p_block"
+version = "0.3.0-beta-dev.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942cf83a44c5d59ca4eb5cc885afce822693f6f9b84480eebedbbf8f751f918c"
+dependencies = [
+ "kitsune_p2p_bin_data",
+ "kitsune_p2p_timestamp",
+ "serde",
+]
+
+[[package]]
+name = "kitsune_p2p_bootstrap"
+version = "0.2.0-beta-dev.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258fc270e0f3a96719e8a32969bb66dc19f23d9a5ac6b3369655e58ed8f046eb"
+dependencies = [
+ "clap 4.4.8",
+ "futures",
+ "kitsune_p2p_bin_data",
+ "kitsune_p2p_types",
+ "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_bytes",
+ "thiserror",
+ "tokio",
+ "warp",
+]
+
+[[package]]
+name = "kitsune_p2p_bootstrap_client"
+version = "0.3.0-beta-dev.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a07011c697bd39f12074117ae6d9b14be98d9c8af767bf5666c0527ea5796cf"
+dependencies = [
+ "ed25519-dalek",
+ "kitsune_p2p_bin_data",
+ "kitsune_p2p_bootstrap",
+ "kitsune_p2p_types",
+ "once_cell",
+ "reqwest",
+ "serde",
+ "serde_bytes",
+ "tokio",
+ "url2",
+]
+
+[[package]]
+name = "kitsune_p2p_dht"
+version = "0.3.0-beta-dev.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0b2e698128153ff17390b52fb7f8c2d02c60b6b5542a6c3365aae854f83bbd6"
 dependencies = [
  "derivative",
  "derive_more",
  "futures",
- "kitsune_p2p_dht_arc 0.3.0-beta-dev.12",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kitsune_p2p_dht_arc",
+ "kitsune_p2p_timestamp",
  "must_future",
  "num-traits",
  "once_cell",
@@ -5165,28 +4687,14 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht_arc"
-version = "0.3.0-beta-dev.10"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "derive_more",
- "gcollections",
- "intervallum",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "num-traits",
- "rusqlite",
- "serde",
-]
-
-[[package]]
-name = "kitsune_p2p_dht_arc"
-version = "0.3.0-beta-dev.12"
+version = "0.3.0-beta-dev.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2254e8accf299ffbb4e13030de3fdf890f79255a3b8ebb617f14cf3b10625cd"
+checksum = "0af9d096615e8f604cf5151ffb65bd109f67832e8d5707f878a358bfdced4430"
 dependencies = [
  "derive_more",
  "gcollections",
  "intervallum",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kitsune_p2p_timestamp",
  "num-traits",
  "rusqlite",
  "serde",
@@ -5194,27 +4702,13 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_fetch"
-version = "0.3.0-beta-dev.18"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "derive_more",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "kitsune_p2p_types 0.3.0-beta-dev.16",
- "linked-hash-map",
- "serde",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "kitsune_p2p_fetch"
-version = "0.3.0-beta-dev.20"
+version = "0.3.0-beta-dev.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6431330a67e529506695053dd9b12b14f435e40e316edc6a72ea400afaa2b9b7"
+checksum = "a432580c1031c2d86f6df96f57291b8db690a8b874afb52c4d375c06fbfbdbb0"
 dependencies = [
  "derive_more",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "kitsune_p2p_types 0.3.0-beta-dev.18",
+ "kitsune_p2p_timestamp",
+ "kitsune_p2p_types",
  "linked-hash-map",
  "serde",
  "tokio",
@@ -5237,48 +4731,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "kitsune_p2p_mdns"
-version = "0.3.0-beta-dev.1"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "base64 0.21.3",
- "err-derive 0.3.1",
- "futures-util",
- "libmdns",
- "mdns",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
 name = "kitsune_p2p_proxy"
-version = "0.3.0-beta-dev.16"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "base64 0.21.3",
- "derive_more",
- "futures",
- "holochain_trace 0.3.0-beta-dev.3",
- "kitsune_p2p_transport_quic 0.3.0-beta-dev.16",
- "kitsune_p2p_types 0.3.0-beta-dev.16",
- "serde",
- "serde_bytes",
- "structopt",
- "tokio",
-]
-
-[[package]]
-name = "kitsune_p2p_proxy"
-version = "0.3.0-beta-dev.18"
+version = "0.3.0-beta-dev.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d834dd725a5b3ad21661f1415b8a0c547c221619bc188d1a776238e1bb5ce619"
+checksum = "5155338da38bf6f0258024161ae78e9fbcc249f6ac9902ae628b94ae137e50f0"
 dependencies = [
  "base64 0.21.3",
  "derive_more",
  "futures",
- "holochain_trace 0.3.0-beta-dev.5",
- "kitsune_p2p_transport_quic 0.3.0-beta-dev.18",
- "kitsune_p2p_types 0.3.0-beta-dev.18",
+ "holochain_trace",
+ "kitsune_p2p_transport_quic",
+ "kitsune_p2p_types",
  "serde",
  "serde_bytes",
  "structopt",
@@ -5297,40 +4760,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "kitsune_p2p_timestamp"
-version = "0.3.0-beta-dev.5"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "chrono",
- "rusqlite",
- "serde",
-]
-
-[[package]]
 name = "kitsune_p2p_transport_quic"
-version = "0.3.0-beta-dev.16"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "blake2b_simd 1.0.1",
- "futures",
- "if-addrs 0.8.0",
- "kitsune_p2p_types 0.3.0-beta-dev.16",
- "quinn",
- "rustls",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "kitsune_p2p_transport_quic"
-version = "0.3.0-beta-dev.18"
+version = "0.3.0-beta-dev.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d576bc7441a757773c527a043029f93fda2ab559a6d045203a4ce04c03f71c70"
+checksum = "fb527cae1486596b2c4e65c0acba7568e0d897fad67992868579c56bbe78df56"
 dependencies = [
  "blake2b_simd 1.0.1",
  "futures",
  "if-addrs 0.8.0",
- "kitsune_p2p_types 0.3.0-beta-dev.18",
+ "kitsune_p2p_types",
  "quinn",
  "rustls",
  "tokio",
@@ -5339,51 +4777,20 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_types"
-version = "0.3.0-beta-dev.16"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "base64 0.21.3",
- "derive_more",
- "futures",
- "ghost_actor 0.3.0-alpha.6",
- "holochain_trace 0.3.0-beta-dev.3",
- "kitsune_p2p_bin_data 0.3.0-beta-dev.11",
- "kitsune_p2p_dht 0.3.0-beta-dev.12",
- "kitsune_p2p_dht_arc 0.3.0-beta-dev.10",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
- "lair_keystore_api",
- "once_cell",
- "parking_lot 0.12.1",
- "paste",
- "rmp-serde 0.15.5",
- "rustls",
- "serde",
- "serde_bytes",
- "serde_json",
- "sysinfo 0.29.10",
- "thiserror",
- "tokio",
- "ureq",
- "url 2.4.1",
- "url2",
-]
-
-[[package]]
-name = "kitsune_p2p_types"
-version = "0.3.0-beta-dev.18"
+version = "0.3.0-beta-dev.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "690729065c85a6b5faf7e5674918c6979933a61a1bfd1490f81afa8b8a084efd"
+checksum = "891c62bb62aece0fa1a391e90dfadb3b4b885212426d090492f5b54d718a6b15"
 dependencies = [
  "base64 0.21.3",
  "derive_more",
  "futures",
  "ghost_actor 0.3.0-alpha.6",
- "holochain_trace 0.3.0-beta-dev.5",
- "kitsune_p2p_bin_data 0.3.0-beta-dev.13",
- "kitsune_p2p_dht 0.3.0-beta-dev.14",
- "kitsune_p2p_dht_arc 0.3.0-beta-dev.12",
- "kitsune_p2p_timestamp 0.3.0-beta-dev.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lair_keystore_api",
+ "holochain_trace",
+ "kitsune_p2p_bin_data",
+ "kitsune_p2p_dht",
+ "kitsune_p2p_dht_arc",
+ "kitsune_p2p_timestamp",
+ "lair_keystore_api 0.4.0",
  "once_cell",
  "parking_lot 0.12.1",
  "paste",
@@ -5456,11 +4863,11 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843c7dbcbc8d75eef0b30397a7eb0d04549aabeff4ea69ebd272aea991555746"
+checksum = "0e71d9d2e55c66921ef9f39fbd393e2430d64f7ac6e83784ff2c777ec8142ec7"
 dependencies = [
- "lair_keystore_api",
+ "lair_keystore_api 0.4.0",
  "pretty_assertions",
  "rpassword 7.2.0",
  "rusqlite",
@@ -5478,7 +4885,34 @@ checksum = "5829f25d0eab6309ae4307aa645f123a64e568a41ec17c358dcbd65dec207e10"
 dependencies = [
  "base64 0.13.1",
  "dunce",
- "hc_seed_bundle",
+ "hc_seed_bundle 0.1.7",
+ "lru",
+ "nanoid 0.4.0",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "rcgen",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.9.25",
+ "time 0.3.23",
+ "tokio",
+ "toml 0.5.11",
+ "toml 0.7.6",
+ "tracing",
+ "url 2.4.1",
+ "winapi 0.3.9",
+ "zeroize",
+]
+
+[[package]]
+name = "lair_keystore_api"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af33456610975b9138a8a8b2051fdeab69743f63d32adbb3f47d5fb8ce329663"
+dependencies = [
+ "base64 0.13.1",
+ "dunce",
+ "hc_seed_bundle 0.2.0",
  "lru",
  "nanoid 0.4.0",
  "once_cell",
@@ -5503,11 +4937,11 @@ version = "0.1.0"
 dependencies = [
  "ascii",
  "async-trait",
- "holochain_conductor_api 0.3.0-beta-dev.29",
+ "holochain_conductor_api",
  "holochain_launcher_utils",
- "holochain_types 0.3.0-beta-dev.26",
- "holochain_zome_types 0.3.0-beta-dev.20",
- "lair_keystore_api",
+ "holochain_types",
+ "holochain_zome_types",
+ "lair_keystore_api 0.3.0",
  "log",
  "nanoid 0.4.0",
  "serde",
@@ -5939,7 +5373,7 @@ version = "0.88.1"
 source = "git+https://github.com/matthme/hc-zome-mere-memory?branch=holochain-0.3.0-beta-dev.20#4c3beb677fde4ae619a220dfd62f1aed35d43336"
 dependencies = [
  "getrandom 0.2.7",
- "hdi 0.4.0-beta-dev.22",
+ "hdi",
  "serde",
  "sha2 0.10.7",
 ]
@@ -6029,36 +5463,16 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "mr_bundle"
-version = "0.3.0-beta-dev.3"
+version = "0.3.0-beta-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62892846095d6a57e622802cd297e7029217025798308d192de79c88e126c48"
+checksum = "9e2823f7044532fd0cab3cb21bd9ee4ef82295db4db32502321bc821368d3215"
 dependencies = [
  "bytes",
  "derive_more",
  "either",
  "flate2",
  "futures",
- "holochain_util 0.3.0-beta-dev.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest",
- "rmp-serde 0.15.5",
- "serde",
- "serde_bytes",
- "serde_derive",
- "serde_yaml 0.9.25",
- "thiserror",
-]
-
-[[package]]
-name = "mr_bundle"
-version = "0.3.0-beta-dev.3"
-source = "git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21#21584d0d3f4562641b438537bd0edb7e4837af21"
-dependencies = [
- "bytes",
- "derive_more",
- "either",
- "flate2",
- "futures",
- "holochain_util 0.3.0-beta-dev.3 (git+https://github.com/holochain/holochain?rev=21584d0d3f4562641b438537bd0edb7e4837af21)",
+ "holochain_util",
  "reqwest",
  "rmp-serde 0.15.5",
  "serde",
@@ -10059,9 +9473,9 @@ dependencies = [
 
 [[package]]
 name = "tx5"
-version = "0.0.5-alpha"
+version = "0.0.6-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f91696fd3614f0fca86fa4f42e4639472eaa6adfb7f5d0bb0b630f824f6591"
+checksum = "bd134f3accf5bb9027cf69de1fef04728d9459e22fecf520a18623bc13831f49"
 dependencies = [
  "bytes",
  "futures",
@@ -10083,9 +9497,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-core"
-version = "0.0.5-alpha"
+version = "0.0.6-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d75f1bd2a341413a006ca67060b117ad2a88c16510cdcb8a95ac7f71fb2d49"
+checksum = "d04199b3ea6873836b444fda70982bb5566a64b13ae9cebed64d0faac7d25892"
 dependencies = [
  "base64 0.13.1",
  "dirs",
@@ -10101,9 +9515,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion"
-version = "0.0.5-alpha"
+version = "0.0.6-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ace6ad58b7f2376f2cb15223c7191dae485fe9be96176c69823252e509b0ad"
+checksum = "aec1c77232fe9307aa37749545c1722d54abc0a19b745cb6b0c4033f33042673"
 dependencies = [
  "futures",
  "parking_lot 0.12.1",
@@ -10115,9 +9529,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion-sys"
-version = "0.0.5-alpha"
+version = "0.0.6-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5d2ffe9dfcb9c458bd761927120df70ae7f00bc96c5c7515912947ac48dec9"
+checksum = "f914c7e4724adc3061f12e449d36cefb1b476a07ca77da601bda645e8c3e58e5"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -10134,9 +9548,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion-turn"
-version = "0.0.5-alpha"
+version = "0.0.6-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252173d1e028b0e4909d596bb174bceffcb47bcc4abb6deb072470230fd0830c"
+checksum = "3af0ed5298942b171593fd1842e50f507da0aae34b64e80f55daad4c15e33a7b"
 dependencies = [
  "base64 0.13.1",
  "dirs",
@@ -10152,12 +9566,12 @@ dependencies = [
 
 [[package]]
 name = "tx5-signal"
-version = "0.0.5-alpha"
+version = "0.0.6-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14bdea8228e5a9760d2a40ea15ce91432358d97866ba070d05a5896a6dffa762"
+checksum = "9324b127b0b0d63a723c4fd2d09b9d5491686878b02b1ccfbe61b898b045845c"
 dependencies = [
  "futures",
- "lair_keystore_api",
+ "lair_keystore_api 0.4.0",
  "once_cell",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -10181,9 +9595,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-signal-srv"
-version = "0.0.5-alpha"
+version = "0.0.6-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4db58c14ceb436a89e6db4f1f602e6e44198ad60bc0efd0d22c4a0348ffd09a"
+checksum = "95d19b62bad76105f28ae9aa5338a4d765546ffa6162223ad3204352a3afa2a2"
 dependencies = [
  "clap 4.4.8",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,14 +74,15 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom 0.2.7",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -560,6 +561,18 @@ dependencies = [
  "derive_more",
  "serde",
  "shrinkwraprs",
+]
+
+[[package]]
+name = "backon"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a6197b2120bb2185a267f6515038558b019e92b832bb0320e96d66268dcf9"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "pin-project 1.1.3",
+ "tokio",
 ]
 
 [[package]]
@@ -1623,7 +1636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if 1.0.0",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
  "lock_api 0.4.10",
  "once_cell",
  "parking_lot_core 0.9.8",
@@ -1694,7 +1707,7 @@ dependencies = [
  "hc_crud_caps",
  "hdk",
  "hex",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "serde",
  "serde_yaml 0.8.26",
  "sha2 0.10.7",
@@ -2814,16 +2827,16 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.7",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.7",
  "allocator-api2",
 ]
 
@@ -2833,7 +2846,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -2849,28 +2862,13 @@ dependencies = [
 
 [[package]]
 name = "hc_seed_bundle"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded13e388a81713db6919cd750e6113acf2fe5afbaedf8aff79780ec4fc47425"
-dependencies = [
- "futures",
- "one_err",
- "rmp-serde 1.1.2",
- "rmpv",
- "serde",
- "serde_bytes",
- "sodoken",
-]
-
-[[package]]
-name = "hc_seed_bundle"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397f372672597305f39af2b2abf389a077077489bc4f412e7ed574214c268208"
 dependencies = [
  "futures",
  "one_err",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "rmpv",
  "serde",
  "serde_bytes",
@@ -2879,9 +2877,9 @@ dependencies = [
 
 [[package]]
 name = "hc_sleuth"
-version = "0.2.0-beta-dev.2"
+version = "0.2.0-beta-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4883350cf8e5a2adc16e083b088ad1678bcc11a3216682ef775fa7a08208ced5"
+checksum = "cf9310bcaa75149b6a4372e8627ca7f0e74fbb52f33967a3bbf4100cb11c51c4"
 dependencies = [
  "aitia",
  "anyhow",
@@ -2902,9 +2900,9 @@ dependencies = [
 
 [[package]]
 name = "hdi"
-version = "0.4.0-beta-dev.23"
+version = "0.4.0-beta-dev.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb9de103346599892e1b5e451afb08e8e1dc78e82e66241e469d9a7fc459ebd"
+checksum = "e7d7d9d3870d4abaf08e6c766b4bbe5e1e8d84b4ccc5337c5ad31bfaf3707f6e"
 dependencies = [
  "hdk_derive",
  "holo_hash",
@@ -2919,9 +2917,9 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.3.0-beta-dev.27"
+version = "0.3.0-beta-dev.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c168b350267fbab81ae0571e686c6644f578c1468f03a61d04c5d874181b084e"
+checksum = "bdd59db2b761da48371518cb5fe0fe44d6191d5a7c4d080a17b71c7e7f65ecee"
 dependencies = [
  "getrandom 0.2.7",
  "hdi",
@@ -2939,9 +2937,9 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.3.0-beta-dev.22"
+version = "0.3.0-beta-dev.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aa32ba721a36233d1f8d7f00a8294c23ded0fc71c10fc0cf7f1262410c9bf6"
+checksum = "febd6cc349ec5dc50172d44952383030738baefaca54b89dc352348ab472a058"
 dependencies = [
  "darling 0.14.4",
  "heck 0.4.1",
@@ -3030,9 +3028,9 @@ dependencies = [
 
 [[package]]
 name = "holo_hash"
-version = "0.3.0-beta-dev.19"
+version = "0.3.0-beta-dev.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd53837f2bcd89f84c68d052c413f221bbc0ea37f18e088128592e0757915fa"
+checksum = "f90cbcabb1ddab56280eb9fb6da068eadaf799660a2d81835b73b6266ba681f8"
 dependencies = [
  "base64 0.13.1",
  "blake2b_simd 0.5.11",
@@ -3053,9 +3051,9 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.3.0-beta-dev.32"
+version = "0.3.0-beta-dev.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d18e5df01f9f574edc32cc8b299f31f53b62bf8f8b4fe87ce6f614b27935a"
+checksum = "220f8a2ca29f17393203013c73cec1b84af89bed130c07051fcf483f74754b16"
 dependencies = [
  "aitia",
  "anyhow",
@@ -3195,9 +3193,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.3.0-beta-dev.32"
+version = "0.3.0-beta-dev.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfcdf0efb6fc0a661b175104c1dd7ff628b5d6995afce7465fc0004334a91c4"
+checksum = "dc2c0309799b27bd26624598069843574d411edcb67d8d6e2af19b5146cd2411"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -3245,7 +3243,7 @@ dependencies = [
  "holochain_types",
  "holochain_util",
  "holochain_zome_types",
- "lair_keystore_api 0.3.0",
+ "lair_keystore_api",
  "log",
  "mime_guess",
  "notify",
@@ -3266,9 +3264,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_sandbox"
-version = "0.3.0-beta-dev.32"
+version = "0.3.0-beta-dev.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de7642b2505184fc902be19b85691c7c6345ce484e0f5fb56f4f8f9ebaf8ed8"
+checksum = "2294b4ab175142ee7d9a54facab3b755be76650658cb4ebabd0bdcc8ba56ce05"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -3316,9 +3314,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.3.0-beta-dev.32"
+version = "0.3.0-beta-dev.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe04944d03cf9276ac44edf6f4418b28c670159a371dc0645dc79c0a3622f297"
+checksum = "c4f30dfd7643e73bde5050ce7453c8209568a58e16410532b6a8b646da174641"
 dependencies = [
  "derive_more",
  "directories",
@@ -3342,9 +3340,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_services"
-version = "0.2.0-beta-dev.3"
+version = "0.2.0-beta-dev.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd9296de01d9600a78dc2dd5b6425d1108255089d0f61db23ab67d60027942"
+checksum = "d2a3a4abc976dfb7e9cb280d127105902fac9b27b389c3b97c624663f8398746"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3360,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.3.0-beta-dev.22"
+version = "0.3.0-beta-dev.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b02dd420083ff5fe785e66ef81aad61d99a93494c211881da58ce7a718305f7d"
+checksum = "5980e72dd76046d3630b7f3201282b087f410ec4807f541da136617cc81ebaee"
 dependencies = [
  "derive_builder",
  "holo_hash",
@@ -3380,9 +3378,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.3.0-beta-dev.24"
+version = "0.3.0-beta-dev.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f2d1738575b40936d03dfe35d28579a01469ef242fb57dec7dc292eaf67845"
+checksum = "5898691962b9ff928bb8f19731dd62930de04bb6ed646eb95c5b6676b2259ecf"
 dependencies = [
  "base64 0.13.1",
  "derive_more",
@@ -3415,7 +3413,7 @@ dependencies = [
  "holochain_conductor_api",
  "holochain_types",
  "holochain_zome_types",
- "lair_keystore_api 0.3.0",
+ "lair_keystore_api",
  "log",
  "mime_guess",
  "open 5.0.0",
@@ -3475,9 +3473,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_p2p"
-version = "0.3.0-beta-dev.31"
+version = "0.3.0-beta-dev.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930fc5bad82c442ba6efbfc9f80dd76f164933a6d2a3024217e758996bc8d279"
+checksum = "d469519acfa0e2246c7e1dae0ff641931914d9890b879ccb92a59b7649ea5f66"
 dependencies = [
  "aitia",
  "async-trait",
@@ -3524,7 +3522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7a5fc7c745a107f8ebcb04caab7a6b7a8463e2811f07ced19c281977583de7"
 dependencies = [
  "holochain_serialized_bytes_derive",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "serde",
  "serde-transcode",
  "serde_bytes",
@@ -3544,9 +3542,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_sqlite"
-version = "0.3.0-beta-dev.29"
+version = "0.3.0-beta-dev.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "676c07bea6392cbbd26b4b6614e889f14d8d30ed7ded2706c75e68e01a005517"
+checksum = "5ac886fcf70f684a1f0c8a089b70fb001fc48626a869f3993429f5bc330cab2f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3573,7 +3571,7 @@ dependencies = [
  "pretty_assertions",
  "r2d2",
  "r2d2_sqlite_neonphog",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "rusqlite",
  "scheduled-thread-pool",
  "serde",
@@ -3589,9 +3587,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.3.0-beta-dev.31"
+version = "0.3.0-beta-dev.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0ea98391de9c18a048d8497f45305d07ce3362c41ee7789911eab0371612c1"
+checksum = "5c5d331d082b206ff0a3501304cb8c5e69d921524f7ac0768b56334e8f9704f3"
 dependencies = [
  "aitia",
  "async-recursion 0.3.2",
@@ -3630,9 +3628,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_state_types"
-version = "0.3.0-beta-dev.29"
+version = "0.3.0-beta-dev.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a27cf7329bb2fd1c9f65de3f6dbbcec9d83ffe83f3c35022fbcc175fdd0f7cc"
+checksum = "65935ea0cb68012da66e31b591e94c7e5bb344eaaa975c6bc6db9757faec2340"
 dependencies = [
  "holo_hash",
  "holochain_integrity_types",
@@ -3659,9 +3657,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.3.0-beta-dev.29"
+version = "0.3.0-beta-dev.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfe8c486c91e9074a79e0ef00acf0bc84ca35701c90d17bed441c27ef4c506c"
+checksum = "eb51df008c698d668a43d450f296c37d0c833e789d64332a1170e418b937c747"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3711,8 +3709,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "wasmer",
- "wasmer-middlewares",
 ]
 
 [[package]]
@@ -3736,9 +3732,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_test_utils"
-version = "0.3.0-beta-dev.30"
+version = "0.3.0-beta-dev.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3990f2e2602bff51e08e020188c8190d5474f959aa576fb460fbf18afe1fcded"
+checksum = "bab93d3e7ebc9c87fd29c3658409bb9be695e04650005d885c81ba6afdf33af1"
 dependencies = [
  "holochain_types",
  "holochain_util",
@@ -3750,9 +3746,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_common"
-version = "0.0.91"
+version = "0.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91334617b53995b436796417abf4cfca516c33404842e60025c26321329c8734"
+checksum = "72007fd2a72d77e76ffa494e5847bf6e893e25e73fe1d1de902e1b8d5033a64e"
 dependencies = [
  "holochain_serialized_bytes",
  "serde",
@@ -3764,9 +3760,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_guest"
-version = "0.0.91"
+version = "0.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a4e3dcf97f42847f0ea8a4ed33d6ccf718764ed00f5a73390e9b4e5319b719"
+checksum = "8c429e84a19ee446f47541a6fed10e1a4376a8a8ba6d3dbff7d07e4a7bb4c85f"
 dependencies = [
  "holochain_serialized_bytes",
  "holochain_wasmer_common",
@@ -3778,9 +3774,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_host"
-version = "0.0.91"
+version = "0.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e7c5fd84c6b3015d015ebcbc5ec90d95e97390251657dd2700096743626f59"
+checksum = "4951f6e1ac6d294631b3d38b8584c84ff510057ac6adca04d1e244b30c2e0b6b"
 dependencies = [
  "bimap",
  "bytes",
@@ -3816,9 +3812,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_websocket"
-version = "0.3.0-beta-dev.9"
+version = "0.3.0-beta-dev.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7c7149900cfb951a0661a60565d1a69100c348c834f9b32e3cb99123e806d5"
+checksum = "4e576e8a5e2134ae0ab9a72cb0650c62ce848ff84c74749efd85f4aeb93aa5a0"
 dependencies = [
  "futures",
  "ghost_actor 0.4.0-alpha.5",
@@ -3841,9 +3837,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.3.0-beta-dev.23"
+version = "0.3.0-beta-dev.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33155846e8a1bbf2125f52bea5297d5f8e28d25c43945460ba6dc3ee3d1df0d"
+checksum = "266040db68dfbb785a4cece54eb73255a711b35c777f8eaba34e64e2d28a92cc"
 dependencies = [
  "derive_builder",
  "holo_hash",
@@ -4169,12 +4165,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -4217,13 +4213,13 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73c0fefcb6d409a6587c07515951495d482006f89a21daa0f2f783aa4fd5e027"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.7",
  "clap 4.4.8",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap 5.5.3",
  "env_logger 0.10.0",
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "is-terminal",
  "itoa 1.0.9",
  "log",
@@ -4558,9 +4554,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0-beta-dev.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bed1f97bd853ddfeae6656382a569ae1b15b076560ffb816ac0df092a1fc6a6"
+checksum = "18380c1845b8863130214a334eab0d3e74378ac907d6f6816768bb6690039ad0"
 dependencies = [
  "arrayref",
  "base64 0.21.3",
@@ -4702,14 +4698,15 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_fetch"
-version = "0.3.0-beta-dev.21"
+version = "0.3.0-beta-dev.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a432580c1031c2d86f6df96f57291b8db690a8b874afb52c4d375c06fbfbdbb0"
+checksum = "7fe36c3239603d4b3b73fb0b01f8662a430f4002b079dd673d81cf57e96d9045"
 dependencies = [
+ "backon",
  "derive_more",
+ "indexmap 2.1.0",
  "kitsune_p2p_timestamp",
  "kitsune_p2p_types",
- "linked-hash-map",
  "serde",
  "tokio",
  "tracing",
@@ -4790,11 +4787,11 @@ dependencies = [
  "kitsune_p2p_dht",
  "kitsune_p2p_dht_arc",
  "kitsune_p2p_timestamp",
- "lair_keystore_api 0.4.0",
+ "lair_keystore_api",
  "once_cell",
  "parking_lot 0.12.1",
  "paste",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "rustls",
  "serde",
  "serde_bytes",
@@ -4867,7 +4864,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e71d9d2e55c66921ef9f39fbd393e2430d64f7ac6e83784ff2c777ec8142ec7"
 dependencies = [
- "lair_keystore_api 0.4.0",
+ "lair_keystore_api",
  "pretty_assertions",
  "rpassword 7.2.0",
  "rusqlite",
@@ -4879,40 +4876,13 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5829f25d0eab6309ae4307aa645f123a64e568a41ec17c358dcbd65dec207e10"
-dependencies = [
- "base64 0.13.1",
- "dunce",
- "hc_seed_bundle 0.1.7",
- "lru",
- "nanoid 0.4.0",
- "once_cell",
- "parking_lot 0.12.1",
- "rcgen",
- "serde",
- "serde_json",
- "serde_yaml 0.9.25",
- "time 0.3.23",
- "tokio",
- "toml 0.5.11",
- "toml 0.7.6",
- "tracing",
- "url 2.4.1",
- "winapi 0.3.9",
- "zeroize",
-]
-
-[[package]]
-name = "lair_keystore_api"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af33456610975b9138a8a8b2051fdeab69743f63d32adbb3f47d5fb8ce329663"
 dependencies = [
  "base64 0.13.1",
  "dunce",
- "hc_seed_bundle 0.2.0",
+ "hc_seed_bundle",
  "lru",
  "nanoid 0.4.0",
  "once_cell",
@@ -4941,7 +4911,7 @@ dependencies = [
  "holochain_launcher_utils",
  "holochain_types",
  "holochain_zome_types",
- "lair_keystore_api 0.3.0",
+ "lair_keystore_api",
  "log",
  "nanoid 0.4.0",
  "serde",
@@ -5474,7 +5444,7 @@ dependencies = [
  "futures",
  "holochain_util",
  "reqwest",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -6326,7 +6296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "quickcheck",
 ]
 
@@ -7391,17 +7361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmp-serde"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
-dependencies = [
- "byteorder",
- "rmp",
- "serde",
-]
-
-[[package]]
 name = "rmpv"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7811,7 +7770,7 @@ version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "itoa 1.0.9",
  "ryu",
  "serde",
@@ -7869,7 +7828,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "serde",
  "serde_json",
  "serde_with_macros 3.3.0",
@@ -7918,7 +7877,7 @@ version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "itoa 1.0.9",
  "ryu",
  "serde",
@@ -9260,7 +9219,7 @@ version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -9571,7 +9530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9324b127b0b0d63a723c4fd2d09b9d5491686878b02b1ccfbe61b898b045845c"
 dependencies = [
  "futures",
- "lair_keystore_api 0.4.0",
+ "lair_keystore_api",
  "once_cell",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -10929,6 +10888,26 @@ dependencies = [
  "serde",
  "static_assertions",
  "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.31",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,26 @@ members = [
 ]
 resolver = "2"
 
+
+[workspace.dependencies]
+# NEW_VERSION Update holochain dependencies here
+holochain = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21", features = ["sqlite-encrypted"] }
+holochain_cli_sandbox = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
+holochain_nonce = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
+holochain_types = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
+holochain_util = { version = "0.3.0-beta-dev.3", features = [ "pw" ] }
+holochain_zome_types = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
+holochain_conductor_api = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
+holochain_trace = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
+holochain_state = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
+
+hdk = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
+
+holochain_client = "0.5.0-dev.25"
+
+lair_keystore_api = "0.3.0"
+
+mr_bundle = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
+
+devhub_types = { git = "https://github.com/matthme/devhub-dnas", branch = "holochain-0.3.0-beta-dev.20" }
+mere_memory_types = { git = "https://github.com/matthme/hc-zome-mere-memory", branch = "holochain-0.3.0-beta-dev.20" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,21 +10,21 @@ resolver = "2"
 
 [workspace.dependencies]
 # NEW_VERSION Update holochain dependencies here
-holochain = { version = "0.3.0-beta-dev.32", features = ["sqlite-encrypted"] }
-holochain_cli_sandbox = "0.3.0-beta-dev.32"
+holochain = { version = "0.3.0-beta-dev.34", features = ["sqlite-encrypted"] }
+holochain_cli_sandbox = "0.3.0-beta-dev.34"
 holochain_nonce = "0.3.0-beta-dev.22"
-holochain_types = "0.3.0-beta-dev.29"
+holochain_types = "0.3.0-beta-dev.31"
 holochain_util = { version = "0.3.0-beta-dev.3", features = [ "pw" ] }
-holochain_zome_types = "0.3.0-beta-dev.23"
-holochain_conductor_api = "0.3.0-beta-dev.32"
+holochain_zome_types = "0.3.0-beta-dev.25"
+holochain_conductor_api = "0.3.0-beta-dev.34"
 holochain_trace = "0.3.0-beta-dev.6"
-holochain_state = "0.3.0-beta-dev.31"
+holochain_state = "0.3.0-beta-dev.33"
 
-hdk = "0.3.0-beta-dev.27"
+hdk = "0.3.0-beta-dev.29"
 
 holochain_client = "0.5.0-dev.25"
 
-lair_keystore_api = "0.3.0"
+lair_keystore_api = "0.4.1"
 
 mr_bundle = "0.3.0-beta-dev.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,23 +10,23 @@ resolver = "2"
 
 [workspace.dependencies]
 # NEW_VERSION Update holochain dependencies here
-holochain = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21", features = ["sqlite-encrypted"] }
-holochain_cli_sandbox = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
-holochain_nonce = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
-holochain_types = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
+holochain = { version = "0.3.0-beta-dev.32", features = ["sqlite-encrypted"] }
+holochain_cli_sandbox = "0.3.0-beta-dev.32"
+holochain_nonce = "0.3.0-beta-dev.22"
+holochain_types = "0.3.0-beta-dev.29"
 holochain_util = { version = "0.3.0-beta-dev.3", features = [ "pw" ] }
-holochain_zome_types = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
-holochain_conductor_api = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
-holochain_trace = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
-holochain_state = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
+holochain_zome_types = "0.3.0-beta-dev.23"
+holochain_conductor_api = "0.3.0-beta-dev.32"
+holochain_trace = "0.3.0-beta-dev.6"
+holochain_state = "0.3.0-beta-dev.31"
 
-hdk = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
+hdk = "0.3.0-beta-dev.27"
 
 holochain_client = "0.5.0-dev.25"
 
 lair_keystore_api = "0.3.0"
 
-mr_bundle = { git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
+mr_bundle = "0.3.0-beta-dev.4"
 
 devhub_types = { git = "https://github.com/matthme/devhub-dnas", branch = "holochain-0.3.0-beta-dev.20" }
 mere_memory_types = { git = "https://github.com/matthme/hc-zome-mere-memory", branch = "holochain-0.3.0-beta-dev.20" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.dependencies]
 # NEW_VERSION Update holochain dependencies here
-holochain = { version = "0.3.0-beta-dev.34", features = ["sqlite-encrypted"] }
+holochain = { version = "0.3.0-beta-dev.34" }
 holochain_cli_sandbox = "0.3.0-beta-dev.34"
 holochain_nonce = "0.3.0-beta-dev.22"
 holochain_types = "0.3.0-beta-dev.31"
@@ -24,7 +24,7 @@ hdk = "0.3.0-beta-dev.29"
 
 holochain_client = "0.5.0-dev.25"
 
-lair_keystore_api = "0.4.1"
+lair_keystore_api = "0.4.0"
 
 mr_bundle = "0.3.0-beta-dev.4"
 

--- a/crates/hc_launch/src-tauri/Cargo.toml
+++ b/crates/hc_launch/src-tauri/Cargo.toml
@@ -24,19 +24,19 @@ anyhow = "1.0"
 futures = "0.3"
 
 # NEW_VERSION update holochain dependencies
-holochain_client = "0.5.0-dev.25"
-holochain_cli_sandbox = "0.3.0-beta-dev.25"
+holochain_client = { workspace = true }
+holochain_cli_sandbox = { workspace = true }
 holochain_launcher_utils = { path = "../../holochain_launcher_utils" }
-holochain_types = "0.3.0-beta-dev.22"
-holochain_util = { version = "0.3.0-beta-dev.2", features = [ "pw" ] }
-holochain_zome_types = "0.3.0-beta-dev.17"
-holochain_conductor_api = "0.3.0-beta-dev.25"
-holochain_trace = "0.3.0-beta-dev.2"
+holochain_types = { workspace = true }
+holochain_util = { workspace = true }
+holochain_zome_types = { workspace = true }
+holochain_conductor_api = { workspace = true }
+holochain_trace = { workspace = true }
 
-holochain = { version = "0.3.0-beta-dev.25", features = ["sqlite-encrypted"] }
+holochain = { workspace = true }
 
 
-lair_keystore_api = "0.3.0"
+lair_keystore_api = { workspace = true }
 
 
 clap = { version = "4.0", features = [ "derive", "env" ] }

--- a/crates/hc_launch/src-tauri/src/cli.rs
+++ b/crates/hc_launch/src-tauri/src/cli.rs
@@ -21,7 +21,7 @@ use crate::prepare_webapp;
 use holochain_cli_sandbox::cmds::{Create, Existing, NetworkCmd, NetworkType};
 
 #[derive(Debug, Parser)]
-#[command(version = "0.0.14 (holochain 0.3.0-beta-dev.32)")]
+#[command(version = "0.0.14 (holochain 0.3.0-beta-dev.34)")]
 #[command(author, about, long_about = None)]
 /// Helper for launching holochain apps in a Holochain Launcher environment for testing and development purposes.
 ///

--- a/crates/hc_launch/src-tauri/src/cli.rs
+++ b/crates/hc_launch/src-tauri/src/cli.rs
@@ -560,11 +560,11 @@ pub fn get_running_ports(path: PathBuf, n_expected: usize) -> Vec<u16> {
       Err(e) => match n {
         0 => {
           println!("[hc launch] ERROR: No running sandbox conductors found. If you use the --reuse-conductors flag there need to be existing sandbox conductors running.\n {}", e);
-          panic!("ERROR: No running snadbox conductors found. If you use the --reuse-conductors flag there need to be existing sandbox conductors running.\n {}", e);
+          panic!("ERROR: No running sandbox conductors found. If you use the --reuse-conductors flag there need to be existing sandbox conductors running.\n {}", e);
         }
         _ => {
           println!("[hc launch] ERROR: Not enough running sandbox conductors found. If you use the --reuse-conductors flag there need to be as many running sandbox conductors as mentioned in the .hc file.\n {}", e);
-          panic!("ERROR: No running snadbox conductors found. If you use the --reuse-conductors flag there need to be as many running sandbox conductors as mentioned in the .hc file.\n {}", e);
+          panic!("ERROR: No running sandbox conductors found. If you use the --reuse-conductors flag there need to be as many running sandbox conductors as mentioned in the .hc file.\n {}", e);
         }
       },
     };

--- a/crates/hc_launch/src-tauri/src/cli.rs
+++ b/crates/hc_launch/src-tauri/src/cli.rs
@@ -21,7 +21,7 @@ use crate::prepare_webapp;
 use holochain_cli_sandbox::cmds::{Create, Existing, NetworkCmd, NetworkType};
 
 #[derive(Debug, Parser)]
-#[command(version = "0.0.14 (holochain 0.3.x)")]
+#[command(version = "0.0.14 (holochain 0.3.0-beta-dev.32)")]
 #[command(author, about, long_about = None)]
 /// Helper for launching holochain apps in a Holochain Launcher environment for testing and development purposes.
 ///

--- a/crates/hc_launch/src-tauri/src/launch_tauri.rs
+++ b/crates/hc_launch/src-tauri/src/launch_tauri.rs
@@ -3,34 +3,30 @@
   windows_subsystem = "windows"
 )]
 
-
-use holochain_client::AdminWebsocket;
-use holochain_types::prelude::AgentPubKey;
+use holochain_client::{AdminWebsocket, AgentPubKey};
 use holochain_launcher_utils::window_builder::{happ_window_builder, UISource};
-use tauri::utils::config::AppUrl;
-use tauri::WindowUrl;
-use tauri::{CustomMenuItem, Menu, Submenu};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use tauri::utils::config::AppUrl;
 use tauri::Manager;
 use tauri::RunEvent;
 use tauri::Window;
 use tauri::WindowEvent;
+use tauri::WindowUrl;
+use tauri::{CustomMenuItem, Menu, Submenu};
 use url::Url;
 
 use lair_keystore_api::dependencies::sodoken;
-use lair_keystore_api::{LairClient, ipc_keystore_connect};
-
+use lair_keystore_api::{ipc_keystore_connect, LairClient};
 
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
-
 
 pub fn launch_tauri(
   ui_source: UISource,
   app_id: String,
   local_storage_dir: PathBuf,
   watch: bool,
-  passphrase: sodoken::BufRead
+  passphrase: sodoken::BufRead,
 ) -> () {
   // tauri::async_runtime::set(tokio::runtime::Handle::current());
 
@@ -46,8 +42,9 @@ pub fn launch_tauri(
 
   let builder = match ui_source {
     UISource::Path(_) => tauri::Builder::default(),
-    UISource::Port(port) => tauri::Builder::default()
-    .plugin(tauri_plugin_localhost::Builder::new(port).build())
+    UISource::Port(port) => {
+      tauri::Builder::default().plugin(tauri_plugin_localhost::Builder::new(port).build())
+    }
   };
 
   // build tauri windows
@@ -67,7 +64,10 @@ pub fn launch_tauri(
       let dot_hc_content = match std::fs::read_to_string(dot_hc_path) {
         Ok(p) => p,
         Err(e) => {
-          println!("[hc launch] ERROR: Failed to read content of .hc file: {}", e);
+          println!(
+            "[hc launch] ERROR: Failed to read content of .hc file: {}",
+            e
+          );
           panic!("Failed to read content of .hc file: {}", e);
         }
       };
@@ -88,7 +88,10 @@ pub fn launch_tauri(
             let admin_port = match std::fs::read_to_string(dot_hc_live_path) {
               Ok(p) => p,
               Err(e) => {
-                println!("[hc launch] ERROR: Failed to read content of .hc_live file: {}", e);
+                println!(
+                  "[hc launch] ERROR: Failed to read content of .hc_live file: {}",
+                  e
+                );
                 panic!("Failed to read content of .hc_live file: {}", e);
               }
             };
@@ -98,7 +101,10 @@ pub fn launch_tauri(
             let app_port = match get_app_websocket(admin_port_string).await {
               Ok(ws) => ws,
               Err(e) => {
-                println!("[hc launch] ERROR:  Failed to get app websocket port: {}", e);
+                println!(
+                  "[hc launch] ERROR:  Failed to get app websocket port: {}",
+                  e
+                );
                 panic!("Failed to get app websocket port.");
               }
             };
@@ -106,7 +112,10 @@ pub fn launch_tauri(
             let admin_port = match admin_port.trim().parse::<u16>() {
               Ok(u) => u,
               Err(e) => {
-                println!("[hc launch] ERROR: Failed to convert admin port from String to u16: {}", e);
+                println!(
+                  "[hc launch] ERROR: Failed to convert admin port from String to u16: {}",
+                  e
+                );
                 panic!("Failed to convert admin port from String to u16: {}", e);
               }
             };
@@ -123,32 +132,32 @@ pub fn launch_tauri(
             let app_handle = app.handle();
 
             let mut window_builder = match ui_source.clone() {
-              UISource::Path(ui_path) => {
-                happ_window_builder(
-                  &app_handle,
-                  app_id.clone(),
-                  window_label.clone(),
-                  window_title.clone(),
-                  UISource::Path(ui_path.clone()),
-                  local_storage_dir.clone().join(format!("Conductor-{}-{}", app_counter, sanitized_app_id)),
-                  app_port,
-                  admin_port,
-                  false,
-                )
-              },
-              UISource::Port(ui_port) => {
-                happ_window_builder(
-                  &app_handle,
-                  app_id.clone(),
-                  window_label.clone(),
-                  window_title.clone(),
-                  UISource::Port(ui_port),
-                  local_storage_dir.clone().join(format!("Conductor-{}-{}", app_counter, sanitized_app_id)),
-                  app_port,
-                  admin_port,
-                  false,
-                )
-              }
+              UISource::Path(ui_path) => happ_window_builder(
+                &app_handle,
+                app_id.clone(),
+                window_label.clone(),
+                window_title.clone(),
+                UISource::Path(ui_path.clone()),
+                local_storage_dir
+                  .clone()
+                  .join(format!("Conductor-{}-{}", app_counter, sanitized_app_id)),
+                app_port,
+                admin_port,
+                false,
+              ),
+              UISource::Port(ui_port) => happ_window_builder(
+                &app_handle,
+                app_id.clone(),
+                window_label.clone(),
+                window_title.clone(),
+                UISource::Port(ui_port),
+                local_storage_dir
+                  .clone()
+                  .join(format!("Conductor-{}-{}", app_counter, sanitized_app_id)),
+                app_port,
+                admin_port,
+                false,
+              ),
             };
 
             window_builder = window_builder.inner_size(window_width, window_height);
@@ -158,12 +167,13 @@ pub fn launch_tauri(
                 "Settings",
                 Menu::new().add_item(CustomMenuItem::new("show-devtools", "Show DevTools")),
               )))
-              .build() {
-                Ok(window) => window,
-                Err(e) => {
-                  println!("[hc launch] ERROR: Failed to build window: {}", e);
-                  panic!("Failed to build Window: {:?}", e);
-                }
+              .build()
+            {
+              Ok(window) => window,
+              Err(e) => {
+                println!("[hc launch] ERROR: Failed to build window: {}", e);
+                panic!("Failed to build Window: {:?}", e);
+              }
             };
 
             let a = app.handle().clone();
@@ -184,10 +194,11 @@ pub fn launch_tauri(
             windows.push(window);
 
             // get public key of installed app and add it to the pubkey map used to verify provenance
-            let mut ws = match AdminWebsocket::connect(format!("ws://localhost:{}", admin_port)).await {
-              Ok(ws) => ws,
-              Err(e) => panic!("Failed to connect to admin websocket: {:?}", e),
-            };
+            let mut ws =
+              match AdminWebsocket::connect(format!("ws://localhost:{}", admin_port)).await {
+                Ok(ws) => ws,
+                Err(e) => panic!("Failed to connect to admin websocket: {:?}", e),
+              };
 
             let installed_apps = match ws.list_apps(None).await {
               Ok(apps) => apps,
@@ -217,7 +228,10 @@ pub fn launch_tauri(
               match ipc_keystore_connect(connection_url.clone(), passphrase.clone()).await {
                 Ok(client) => client,
                 Err(e) => {
-                  println!("[hc launch] ERROR: Failed to connect to lair client: {:?}", e);
+                  println!(
+                    "[hc launch] ERROR: Failed to connect to lair client: {:?}",
+                    e
+                  );
                   panic!("Failed to connect to lair client");
                 }
               };
@@ -237,7 +251,10 @@ pub fn launch_tauri(
       // watch for file changes in the UI folder if requested
       match (watch, ui_source) {
         (true, UISource::Path(ui_path)) => {
-          println!("[hc launch] Watching file changes in folder {:?}", ui_path.as_path());
+          println!(
+            "[hc launch] Watching file changes in folder {:?}",
+            ui_path.as_path()
+          );
 
           let _watch_handle = std::thread::spawn(move || {
             let (tx_watcher, rx_watcher) = std::sync::mpsc::channel();
@@ -267,8 +284,10 @@ pub fn launch_tauri(
               }
             }
           });
-        },
-        (true, UISource::Port(_port)) => println!("[hc launch] WARNING: The --watch flag has no effect if the UI is served from localhost."),
+        }
+        (true, UISource::Port(_port)) => println!(
+          "[hc launch] WARNING: The --watch flag has no effect if the UI is served from localhost."
+        ),
         _ => (),
       }
 
@@ -331,7 +350,10 @@ fn read_lair_yaml(path: PathBuf) -> Option<String> {
   ) {
     Ok(content) => content,
     Err(e) => {
-      println!("[hc launch] ERROR: Failed to read lair-keystore-config.yaml: {:?}", e);
+      println!(
+        "[hc launch] ERROR: Failed to read lair-keystore-config.yaml: {:?}",
+        e
+      );
       panic!("Failed to read lair-keystore-config.yaml");
     }
   };
@@ -353,7 +375,9 @@ fn derive_window_label(conductor_nr: i32, app_id: String) -> String {
   return format!("Conductor-{}-{}", conductor_nr, sanitized_app_id);
 }
 
-
 fn sanitize_app_id(app_id: String) -> String {
-  return app_id.replace("-", "--").replace(" ", "-").replace(".", "_");
+  return app_id
+    .replace("-", "--")
+    .replace(" ", "-")
+    .replace(".", "_");
 }

--- a/crates/hc_launch/src-tauri/src/launch_tauri.rs
+++ b/crates/hc_launch/src-tauri/src/launch_tauri.rs
@@ -345,7 +345,7 @@ async fn get_app_websocket(admin_port: String) -> Result<u16, String> {
 fn read_lair_yaml(path: PathBuf) -> Option<String> {
   let yaml_content = match std::fs::read_to_string(
     PathBuf::from(path)
-      .join("keystore")
+      .join("ks")
       .join("lair-keystore-config.yaml"),
   ) {
     Ok(content) => content,

--- a/crates/holochain_launcher_utils/Cargo.toml
+++ b/crates/holochain_launcher_utils/Cargo.toml
@@ -14,14 +14,13 @@ categories = ["command-line-utilities", "development-tools"]
 [dependencies]
 
 # NEW_VERSION update holochain dependencies
-holochain_client = "0.5.0-dev.25"
+holochain_client = { workspace = true }
 
-holochain_conductor_api = "0.3.0-beta-dev.25"
-holochain_types = "0.3.0-beta-dev.22"
-holochain_zome_types = "0.3.0-beta-dev.17"
+holochain_conductor_api = { workspace = true }
+holochain_types = { workspace = true }
+holochain_zome_types = { workspace = true }
 
-lair_keystore_api = "0.3.0"
-
+lair_keystore_api = { workspace = true }
 
 log = "0.4.14"
 mime_guess = "2.0.4"

--- a/crates/holochain_launcher_utils/src/zome_call_signing.rs
+++ b/crates/holochain_launcher_utils/src/zome_call_signing.rs
@@ -1,31 +1,28 @@
-
-use holochain_client::AgentPubKey;
 use holochain_conductor_api::ZomeCall;
-use holochain_types::prelude::ZomeCallUnsigned;
-use holochain_zome_types::prelude::{Signature, CellId, ZomeName, FunctionName, CapSecret, ExternIO, Timestamp};
+use holochain_types::prelude::{AgentPubKey, ZomeCallUnsigned};
+use holochain_zome_types::prelude::{
+  CapSecret, CellId, ExternIO, FunctionName, Signature, Timestamp, ZomeName,
+};
 use lair_keystore_api::LairClient;
 
 use serde::Deserialize;
-
 
 /// Signs an unsigned zome call with the given LairClient
 pub async fn sign_zome_call_with_client(
   zome_call_unsigned: ZomeCallUnsigned,
   client: &LairClient,
 ) -> Result<ZomeCall, String> {
-
   // sign the zome call
   let pub_key = zome_call_unsigned.provenance.clone();
   let mut pub_key_2 = [0; 32];
   pub_key_2.copy_from_slice(pub_key.get_raw_32());
 
-  let data_to_sign = zome_call_unsigned.data_to_sign()
+  let data_to_sign = zome_call_unsigned
+    .data_to_sign()
     .map_err(|e| format!("Failed to get data to sign from unsigned zome call: {}", e))?;
 
-  let sig = client.sign_by_pub_key(
-    pub_key_2.into(),
-     None,
-    data_to_sign)
+  let sig = client
+    .sign_by_pub_key(pub_key_2.into(), None, data_to_sign)
     .await
     .map_err(|e| format!("Failed to sign zome call by pubkey: {}", e.str_kind()))?;
 
@@ -40,17 +37,11 @@ pub async fn sign_zome_call_with_client(
     provenance: zome_call_unsigned.provenance,
     nonce: zome_call_unsigned.nonce,
     expires_at: zome_call_unsigned.expires_at,
-    signature
+    signature,
   };
 
-  return Ok(signed_zome_call)
-
+  return Ok(signed_zome_call);
 }
-
-
-
-
-
 
 /// The version of an unsigned zome call that's compatible with the serialization
 /// behavior of tauri's IPC channel (serde serialization)
@@ -67,7 +58,6 @@ pub struct ZomeCallUnsignedTauri {
   pub nonce: [u8; 32],
   pub expires_at: Timestamp,
 }
-
 
 impl Into<ZomeCallUnsigned> for ZomeCallUnsignedTauri {
   fn into(self) -> ZomeCallUnsigned {

--- a/crates/holochain_manager/Cargo.toml
+++ b/crates/holochain_manager/Cargo.toml
@@ -14,9 +14,9 @@ holochain_client = { workspace = true }
 
 # NEW_VERSION add latest crates here
 
-holochain_conductor_api_0_3_0 = { package = "holochain_conductor_api", git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
-holochain_p2p_0_3_0 = { package = "holochain_p2p", git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
-holochain_types_0_3_0 = { package = "holochain_types", git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
+holochain_conductor_api_0_3_0 = { package = "holochain_conductor_api", version = "0.3.0-beta-dev.32" }
+holochain_p2p_0_3_0 = { package = "holochain_p2p", version = "0.3.0-beta-dev.31" }
+holochain_types_0_3_0 = { package = "holochain_types", version = "0.3.0-beta-dev.29" }
 
 mr_bundle = { workspace = true }
 

--- a/crates/holochain_manager/Cargo.toml
+++ b/crates/holochain_manager/Cargo.toml
@@ -8,17 +8,17 @@ version = "0.1.0"
 [dependencies]
 # NEW_VERSION pick right client version
 
-holochain = { version = "0.3.0-beta-dev.25", features = ["sqlite-encrypted"] }
-holochain_client = "0.5.0-dev.25"
+holochain = { workspace = true }
+holochain_client = { workspace = true }
 
 
 # NEW_VERSION add latest crates here
 
-holochain_conductor_api_0_3_0 = { package = "holochain_conductor_api", version = "0.3.0-beta-dev.25" }
-holochain_p2p_0_3_0 = { package = "holochain_p2p", version = "0.3.0-beta-dev.24" }
-holochain_types_0_3_0 = { package = "holochain_types", version = "0.3.0-beta-dev.22" }
+holochain_conductor_api_0_3_0 = { package = "holochain_conductor_api", git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
+holochain_p2p_0_3_0 = { package = "holochain_p2p", git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
+holochain_types_0_3_0 = { package = "holochain_types", git = "https://github.com/holochain/holochain", rev = "21584d0d3f4562641b438537bd0edb7e4837af21" }
 
-mr_bundle = "0.3.0-beta-dev.2"
+mr_bundle = { workspace = true }
 
 lair_keystore_manager = {path = "../lair_keystore_manager"}
 

--- a/crates/holochain_manager/Cargo.toml
+++ b/crates/holochain_manager/Cargo.toml
@@ -14,9 +14,9 @@ holochain_client = { workspace = true }
 
 # NEW_VERSION add latest crates here
 
-holochain_conductor_api_0_3_0 = { package = "holochain_conductor_api", version = "0.3.0-beta-dev.32" }
-holochain_p2p_0_3_0 = { package = "holochain_p2p", version = "0.3.0-beta-dev.31" }
-holochain_types_0_3_0 = { package = "holochain_types", version = "0.3.0-beta-dev.29" }
+holochain_conductor_api_0_3_0 = { package = "holochain_conductor_api", version = "0.3.0-beta-dev.34" }
+holochain_p2p_0_3_0 = { package = "holochain_p2p", version = "0.3.0-beta-dev.33" }
+holochain_types_0_3_0 = { package = "holochain_types", version = "0.3.0-beta-dev.31" }
 
 mr_bundle = { workspace = true }
 

--- a/crates/holochain_manager/src/versions/mod.rs
+++ b/crates/holochain_manager/src/versions/mod.rs
@@ -56,7 +56,7 @@ impl Into<String> for HdiVersion {
 pub enum HolochainVersion {
   #[serde(rename = "Custom Binary")]
   CustomBinary,
-  #[serde(rename = "0.3.0-beta-dev.25")]
+  #[serde(rename = "0.3.0-beta-dev.34")]
   V0_3_0,
   // Note that the foldername of the conductor database is currently only defined by the
   // minor version, i.e. 0.2

--- a/crates/lair_keystore_manager/Cargo.toml
+++ b/crates/lair_keystore_manager/Cargo.toml
@@ -8,10 +8,10 @@ version = "0.1.0"
 [dependencies]
 
 # NEW_VERSION update holochain_types, holochain_zome_types and holochain_conductor_api here and if necessary also lair_keystore_api
-lair_keystore_api = "0.3.0"
-holochain_conductor_api = "0.3.0-beta-dev.25"
-holochain_types = "0.3.0-beta-dev.22"
-holochain_zome_types = "0.3.0-beta-dev.17"
+lair_keystore_api = { workspace = true }
+holochain_conductor_api = { workspace = true }
+holochain_types = { workspace = true }
+holochain_zome_types = { workspace = true }
 
 holochain_launcher_utils = { path = "../holochain_launcher_utils" }
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -26,9 +26,9 @@ cp $LAIR_PATH src-tauri/bins/lair-keystore-v0.3.0-x86_64-apple-darwin
 cp $LAIR_PATH src-tauri/bins/lair-keystore-v0.3.0-[_ARCHITECTURE_]
 
 
-cargo install holochain --version 0.3.0-beta-dev.25 --features sqlite-encrypted
+cargo install holochain --version 0.3.0-beta-dev.34
 HOLOCHAIN_PATH=$(which holochain)
-cp $HOLOCHAIN_PATH src-tauri/bins/holochain-v0.3.0-beta-dev.25-[_ARCHITECTURE_]
+cp $HOLOCHAIN_PATH src-tauri/bins/holochain-v0.3.0-beta-dev.34-[_ARCHITECTURE_]
 
 
 [... install further holochain versions if required]
@@ -44,9 +44,9 @@ cargo install --version 0.2.4 lair_keystore
 $LkPath = Get-Command lair-keystore | Select-Object -ExpandProperty Definition
 Copy-Item $LkPath -Destination src-tauri/bins/lair-keystore-v0.2.4-x86_64-pc-windows-msvc.exe
 
-cargo install holochain --version 0.3.0-beta-dev.25 --locked --features db-encryption
+cargo install holochain --version 0.3.0-beta-dev.34 --locked --features db-encryption
 $HcPath = Get-Command holochain | Select-Object -ExpandProperty Definition
-Copy-Item $HcPath -Destination src-tauri/bins/holochain-v0.3.0-beta-dev.25-x86_64-pc-windows-msvc.exe
+Copy-Item $HcPath -Destination src-tauri/bins/holochain-v0.3.0-beta-dev.34-x86_64-pc-windows-msvc.exe
 
 [... install further holochain versions if required]
 
@@ -108,6 +108,6 @@ Caused by:
   cargo:rerun-if-changed=tauri.conf.json
   cargo:rustc-cfg=desktop
   cargo:rustc-cfg=dev
-  path matching bins/holochain-v0.3.0-beta-dev.25-aarch64-apple-darwin not found.
+  path matching bins/holochain-v0.3.0-beta-dev.34-aarch64-apple-darwin not found.
 warning: build failed, waiting for other jobs to finish...
 ```

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,16 +26,16 @@ holochain_web_app_manager = { path = "../crates/holochain_web_app_manager" }
 lair_keystore_manager = { path = "../crates/lair_keystore_manager" }
 
 # NEW_VERSION update holochain dependencies
-holochain_types = "0.3.0-beta-dev.22"
-holochain_state = "0.3.0-beta-dev.24"
-holochain_nonce = "0.3.0-beta-dev.22"
-hdk = "0.3.0-beta-dev.20"
+holochain_types = { workspace = true }
+holochain_state = { workspace = true }
+holochain_nonce = { workspace = true }
+hdk = { workspace = true }
 
-holochain = { version = "0.3.0-beta-dev.25", features = ["sqlite-encrypted"] }
+holochain = { workspace = true }
 
-mr_bundle = "0.3.0-beta-dev.2"
+mr_bundle = { workspace = true }
 
-devhub_types = { git = "https://github.com/matthme/devhub-dnas", branch = "holochain-0.3.0-beta-dev.20" }
+devhub_types = { workspace = true }
 
 
 async-recursion = "1.0.4"
@@ -45,7 +45,7 @@ dirs-next = "2.0.0"
 futures = "0.3"
 log = "0.4.14"
 log4rs = "1.0.0"
-mere_memory_types = { git = "https://github.com/matthme/hc-zome-mere-memory", branch = "holochain-0.3.0-beta-dev.20" }
+mere_memory_types = { workspace = true }
 open = "5.0.0"
 opener = "0.6.1"
 portpicker = "0.1.1"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,7 +37,7 @@
       ],
       "resources": [],
       "externalBin": [
-        "bins/holochain-v0.3.0-beta-dev.25",
+        "bins/holochain-v0.3.0-beta-dev.34",
         "bins/lair-keystore-v0.3.0"
       ],
       "copyright": "",


### PR DESCRIPTION
* Moves most of the rust dependencies to the root Cargo.toml
* bumps to holochain-0.3.0-beta-dev.32